### PR TITLE
Replicate the attributed rake value

### DIFF
--- a/HH20200403 3 April 10p BB - 50-100 - Play Money No Limit Hold'em.txt
+++ b/HH20200403 3 April 10p BB - 50-100 - Play Money No Limit Hold'em.txt
@@ -1,0 +1,11287 @@
+﻿PokerStars Home Game Hand #211258814466: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 20:35:27 WET [2020/04/03 15:35:27 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (10000 in chips) 
+Seat 8: winghymliu (10000 in chips) 
+winghymliu: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Qs Kc]
+winghymliu: calls 50
+hellokwanny: raises 200 to 300
+winghymliu: calls 200
+*** FLOP *** [3s 4c Qh]
+hellokwanny: bets 300
+winghymliu: raises 1167 to 1467
+hellokwanny: calls 1167
+*** TURN *** [3s 4c Qh] [9c]
+hellokwanny: checks 
+winghymliu: bets 4300
+hellokwanny: calls 4300
+*** RIVER *** [3s 4c Qh 9c] [5c]
+hellokwanny: checks 
+winghymliu: bets 3933 and is all-in
+hellokwanny: calls 3933 and is all-in
+*** SHOW DOWN ***
+winghymliu: shows [Qd 8c] (a pair of Queens)
+hellokwanny: shows [Qs Kc] (a pair of Queens - King kicker)
+hellokwanny collected 18900 from pot
+*** SUMMARY ***
+Total pot 20000 | Rake 1100 
+Board [3s 4c Qh 9c 5c]
+Seat 1: hellokwanny (big blind) showed [Qs Kc] and won (18900) with a pair of Queens
+Seat 8: winghymliu (button) (small blind) showed [Qd 8c] and lost with a pair of Queens
+
+
+
+PokerStars Home Game Hand #211258951931: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 20:36:59 WET [2020/04/03 15:36:59 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (18900 in chips) 
+Seat 4: pokeher878787 (10000 in chips) 
+Seat 5: scra88le56 (10000 in chips) 
+Seat 9: no1beyondfan888 (10000 in chips) 
+hellokwanny: posts small blind 50
+pokeher878787: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [7s 8c]
+scra88le56: folds 
+no1beyondfan888: calls 100
+hellokwanny: folds 
+pokeher878787: checks 
+*** FLOP *** [9c Kh 8s]
+pokeher878787: checks 
+no1beyondfan888: checks 
+*** TURN *** [9c Kh 8s] [Qd]
+pokeher878787: checks 
+no1beyondfan888: checks 
+*** RIVER *** [9c Kh 8s Qd] [Td]
+pokeher878787: checks 
+no1beyondfan888: bets 236
+pokeher878787: folds 
+Uncalled bet (236) returned to no1beyondfan888
+no1beyondfan888 collected 236 from pot
+no1beyondfan888: doesn't show hand 
+*** SUMMARY ***
+Total pot 250 | Rake 14 
+Board [9c Kh 8s Qd Td]
+Seat 1: hellokwanny (small blind) folded before Flop
+Seat 4: pokeher878787 (big blind) folded on the River
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 (button) collected (236)
+
+
+
+PokerStars Home Game Hand #211259021443: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 20:37:49 WET [2020/04/03 15:37:49 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (18850 in chips) 
+Seat 4: pokeher878787 (9900 in chips) 
+Seat 5: scra88le56 (10000 in chips) 
+Seat 9: no1beyondfan888 (10136 in chips) 
+pokeher878787: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Qh Kd]
+no1beyondfan888: calls 100
+hellokwanny: raises 200 to 300
+pokeher878787: folds 
+scra88le56: folds 
+no1beyondfan888: calls 200
+*** FLOP *** [Qs Jc 3s]
+no1beyondfan888: checks 
+hellokwanny: bets 300
+no1beyondfan888: folds 
+Uncalled bet (300) returned to hellokwanny
+hellokwanny collected 709 from pot
+hellokwanny: doesn't show hand 
+*** SUMMARY ***
+Total pot 750 | Rake 41 
+Board [Qs Jc 3s]
+Seat 1: hellokwanny (button) collected (709)
+Seat 4: pokeher878787 (small blind) folded before Flop
+Seat 5: scra88le56 (big blind) folded before Flop
+Seat 9: no1beyondfan888 folded on the Flop
+
+
+
+PokerStars Home Game Hand #211259074654: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 20:38:24 WET [2020/04/03 15:38:24 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #4 is the button
+Seat 1: hellokwanny (19259 in chips) 
+Seat 4: pokeher878787 (9850 in chips) 
+Seat 5: scra88le56 (9900 in chips) 
+Seat 8: winghymliu (10000 in chips) 
+scra88le56: posts small blind 50
+winghymliu: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [9d As]
+hellokwanny: folds 
+pokeher878787: calls 100
+scra88le56: folds 
+winghymliu: raises 600 to 700
+pokeher878787: folds 
+Uncalled bet (600) returned to winghymliu
+winghymliu collected 250 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 250 | Rake 0 
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 (button) folded before Flop
+Seat 5: scra88le56 (small blind) folded before Flop
+Seat 8: winghymliu (big blind) collected (250)
+
+
+
+PokerStars Home Game Hand #211259128128: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 20:39:03 WET [2020/04/03 15:39:03 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (19259 in chips) 
+Seat 4: pokeher878787 (9750 in chips) 
+Seat 5: scra88le56 (9850 in chips) 
+Seat 8: winghymliu (10150 in chips) 
+Seat 9: no1beyondfan888 (9836 in chips) 
+winghymliu: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [7c 6d]
+hellokwanny: folds 
+pokeher878787: folds 
+scra88le56: calls 100
+winghymliu: calls 50
+no1beyondfan888: checks 
+*** FLOP *** [3h 7d Ks]
+winghymliu: checks 
+no1beyondfan888: bets 141
+scra88le56: calls 141
+winghymliu: folds 
+*** TURN *** [3h 7d Ks] [As]
+no1beyondfan888: checks 
+scra88le56: bets 275
+no1beyondfan888: folds 
+Uncalled bet (275) returned to scra88le56
+scra88le56 collected 550 from pot
+scra88le56: doesn't show hand 
+*** SUMMARY ***
+Total pot 582 | Rake 32 
+Board [3h 7d Ks As]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 folded before Flop (didn't bet)
+Seat 5: scra88le56 (button) collected (550)
+Seat 8: winghymliu (small blind) folded on the Flop
+Seat 9: no1beyondfan888 (big blind) folded on the Turn
+
+
+
+PokerStars Home Game Hand #211259197301: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 20:39:54 WET [2020/04/03 15:39:54 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (19259 in chips) 
+Seat 4: pokeher878787 (9750 in chips) 
+Seat 5: scra88le56 (10159 in chips) 
+Seat 8: winghymliu (10050 in chips) 
+Seat 9: no1beyondfan888 (9595 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [7c Ah]
+pokeher878787: calls 100
+scra88le56: folds 
+winghymliu: folds 
+no1beyondfan888: calls 50
+hellokwanny: checks 
+*** FLOP *** [9h 5s 5d]
+no1beyondfan888: bets 100
+hellokwanny: folds 
+pokeher878787: calls 100
+*** TURN *** [9h 5s 5d] [6h]
+no1beyondfan888: bets 236
+pokeher878787: folds 
+Uncalled bet (236) returned to no1beyondfan888
+no1beyondfan888 collected 472 from pot
+no1beyondfan888: doesn't show hand 
+*** SUMMARY ***
+Total pot 500 | Rake 28 
+Board [9h 5s 5d 6h]
+Seat 1: hellokwanny (big blind) folded on the Flop
+Seat 4: pokeher878787 folded on the Turn
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 8: winghymliu (button) folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 (small blind) collected (472)
+
+
+
+PokerStars Home Game Hand #211259259105: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 20:40:40 WET [2020/04/03 15:40:40 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (19159 in chips) 
+Seat 4: pokeher878787 (9550 in chips) 
+Seat 5: scra88le56 (10159 in chips) 
+Seat 8: winghymliu (10050 in chips) 
+Seat 9: no1beyondfan888 (9867 in chips) 
+hellokwanny: posts small blind 50
+pokeher878787: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Th 9c]
+scra88le56: folds 
+winghymliu: calls 100
+no1beyondfan888: calls 100
+hellokwanny: folds 
+pokeher878787: checks 
+*** FLOP *** [6s 7h 4d]
+pokeher878787: checks 
+winghymliu: bets 100
+no1beyondfan888: folds 
+pokeher878787: calls 100
+*** TURN *** [6s 7h 4d] [2c]
+pokeher878787: checks 
+winghymliu: checks 
+*** RIVER *** [6s 7h 4d 2c] [2s]
+pokeher878787: checks 
+winghymliu: checks 
+*** SHOW DOWN ***
+pokeher878787: shows [3h Qh] (a pair of Deuces)
+winghymliu: mucks hand 
+pokeher878787 collected 520 from pot
+*** SUMMARY ***
+Total pot 550 | Rake 30 
+Board [6s 7h 4d 2c 2s]
+Seat 1: hellokwanny (small blind) folded before Flop
+Seat 4: pokeher878787 (big blind) showed [3h Qh] and won (520) with a pair of Deuces
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 8: winghymliu mucked [9h 8s]
+Seat 9: no1beyondfan888 (button) folded on the Flop
+
+
+
+PokerStars Home Game Hand #211259350591: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 20:41:47 WET [2020/04/03 15:41:47 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (19109 in chips) 
+Seat 4: pokeher878787 (9870 in chips) 
+Seat 5: scra88le56 (10159 in chips) 
+Seat 8: winghymliu (9850 in chips) 
+Seat 9: no1beyondfan888 (9767 in chips) 
+pokeher878787: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [4d 2c]
+winghymliu: calls 100
+no1beyondfan888: calls 100
+hellokwanny: folds 
+pokeher878787: calls 50
+scra88le56: raises 700 to 800
+winghymliu: folds 
+no1beyondfan888: calls 700
+pokeher878787: folds 
+*** FLOP *** [8c 8d Qh]
+scra88le56: checks 
+no1beyondfan888: bets 850
+scra88le56: calls 850
+*** TURN *** [8c 8d Qh] [Qs]
+scra88le56: checks 
+no1beyondfan888: bets 3307
+scra88le56: calls 3307
+*** RIVER *** [8c 8d Qh Qs] [6d]
+scra88le56: checks 
+no1beyondfan888: checks 
+*** SHOW DOWN ***
+scra88le56: shows [Kc As] (two pair, Queens and Eights)
+no1beyondfan888: shows [9h Ad] (two pair, Queens and Eights)
+scra88le56 collected 4779 from pot
+no1beyondfan888 collected 4779 from pot
+*** SUMMARY ***
+Total pot 10114 | Rake 556 
+Board [8c 8d Qh Qs 6d]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 4: pokeher878787 (small blind) folded before Flop
+Seat 5: scra88le56 (big blind) showed [Kc As] and won (4779) with two pair, Queens and Eights
+Seat 8: winghymliu folded before Flop
+Seat 9: no1beyondfan888 showed [9h Ad] and won (4779) with two pair, Queens and Eights
+
+
+
+PokerStars Home Game Hand #211259452952: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 20:43:00 WET [2020/04/03 15:43:00 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #4 is the button
+Seat 1: hellokwanny (19109 in chips) 
+Seat 4: pokeher878787 (9770 in chips) 
+Seat 5: scra88le56 (9981 in chips) 
+Seat 8: winghymliu (9750 in chips) 
+scra88le56: posts small blind 50
+winghymliu: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [2h 9d]
+hellokwanny: folds 
+pokeher878787: calls 100
+scra88le56: raises 1000 to 1100
+winghymliu: calls 1000
+pokeher878787: folds 
+*** FLOP *** [Js 9h 2s]
+scra88le56: bets 1200
+winghymliu: folds 
+Uncalled bet (1200) returned to scra88le56
+scra88le56 collected 2173 from pot
+scra88le56: doesn't show hand 
+*** SUMMARY ***
+Total pot 2300 | Rake 127 
+Board [Js 9h 2s]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 (button) folded before Flop
+Seat 5: scra88le56 (small blind) collected (2173)
+Seat 8: winghymliu (big blind) folded on the Flop
+
+
+
+PokerStars Home Game Hand #211259517800: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 20:43:47 WET [2020/04/03 15:43:47 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (19109 in chips) 
+Seat 4: pokeher878787 (9670 in chips) 
+Seat 5: scra88le56 (11054 in chips) 
+Seat 8: winghymliu (8650 in chips) 
+winghymliu: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [4c Jh]
+pokeher878787: calls 100
+scra88le56: calls 100
+winghymliu: folds 
+hellokwanny: checks 
+*** FLOP *** [Jd Th 9s]
+hellokwanny: checks 
+pokeher878787: bets 165
+scra88le56: calls 165
+hellokwanny: folds 
+*** TURN *** [Jd Th 9s] [3s]
+pokeher878787: bets 321
+scra88le56: calls 321
+*** RIVER *** [Jd Th 9s 3s] [4d]
+pokeher878787: bets 624
+scra88le56: raises 624 to 1248
+pokeher878787: folds 
+Uncalled bet (624) returned to scra88le56
+scra88le56 collected 2429 from pot
+scra88le56: doesn't show hand 
+*** SUMMARY ***
+Total pot 2570 | Rake 141 
+Board [Jd Th 9s 3s 4d]
+Seat 1: hellokwanny (big blind) folded on the Flop
+Seat 4: pokeher878787 folded on the River
+Seat 5: scra88le56 (button) collected (2429)
+Seat 8: winghymliu (small blind) folded before Flop
+
+
+
+PokerStars Home Game Hand #211259611506: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 20:44:55 WET [2020/04/03 15:44:55 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (19009 in chips) 
+Seat 4: pokeher878787 (8460 in chips) 
+Seat 5: scra88le56 (12273 in chips) 
+Seat 8: winghymliu (8600 in chips) 
+hellokwanny: posts small blind 50
+pokeher878787: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [8c 2c]
+scra88le56: calls 100
+winghymliu: calls 100
+hellokwanny: folds 
+pokeher878787: checks 
+*** FLOP *** [Th 8d Ks]
+pokeher878787: bets 165
+scra88le56: calls 165
+winghymliu: folds 
+*** TURN *** [Th 8d Ks] [Kc]
+pokeher878787: bets 789
+scra88le56: calls 789
+*** RIVER *** [Th 8d Ks Kc] [3s]
+pokeher878787: bets 3456
+scra88le56: raises 7763 to 11219 and is all-in
+pokeher878787: calls 3950 and is all-in
+Uncalled bet (3813) returned to scra88le56
+*** SHOW DOWN ***
+scra88le56: shows [9h Ts] (two pair, Kings and Tens)
+pokeher878787: shows [Kd 4h] (three of a kind, Kings)
+pokeher878787 collected 16131 from pot
+*** SUMMARY ***
+Total pot 17070 | Rake 939 
+Board [Th 8d Ks Kc 3s]
+Seat 1: hellokwanny (small blind) folded before Flop
+Seat 4: pokeher878787 (big blind) showed [Kd 4h] and won (16131) with three of a kind, Kings
+Seat 5: scra88le56 showed [9h Ts] and lost with two pair, Kings and Tens
+Seat 8: winghymliu (button) folded on the Flop
+
+
+
+PokerStars Home Game Hand #211259699600: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 20:45:58 WET [2020/04/03 15:45:58 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (18959 in chips) 
+Seat 4: pokeher878787 (16131 in chips) 
+Seat 5: scra88le56 (3813 in chips) 
+Seat 8: winghymliu (8500 in chips) 
+Seat 9: no1beyondfan888 (9589 in chips) 
+pokeher878787: posts small blind 50
+scra88le56: posts big blind 100
+no1beyondfan888: posts small & big blinds 150
+*** HOLE CARDS ***
+Dealt to hellokwanny [6h Td]
+winghymliu: folds 
+no1beyondfan888: checks 
+hellokwanny: folds 
+pokeher878787: raises 200 to 300
+scra88le56: calls 200
+no1beyondfan888: calls 200
+*** FLOP *** [5s 7d Th]
+pokeher878787: bets 449
+scra88le56: folds 
+no1beyondfan888: folds 
+Uncalled bet (449) returned to pokeher878787
+pokeher878787 collected 898 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 950 | Rake 52 
+Board [5s 7d Th]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 4: pokeher878787 (small blind) collected (898)
+Seat 5: scra88le56 (big blind) folded on the Flop
+Seat 8: winghymliu folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 folded on the Flop
+
+
+
+PokerStars Home Game Hand #211259750209: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 20:46:34 WET [2020/04/03 15:46:34 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #4 is the button
+Seat 1: hellokwanny (18959 in chips) 
+Seat 4: pokeher878787 (16729 in chips) 
+Seat 5: scra88le56 (3513 in chips) 
+Seat 8: winghymliu (8500 in chips) 
+Seat 9: no1beyondfan888 (9239 in chips) 
+scra88le56: posts small blind 50
+winghymliu: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [3h 2s]
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: calls 100
+scra88le56: calls 50
+winghymliu: checks 
+*** FLOP *** [8s 9s 2c]
+scra88le56: bets 700
+winghymliu: calls 700
+pokeher878787: calls 700
+*** TURN *** [8s 9s 2c] [3s]
+scra88le56: checks 
+winghymliu: bets 2268
+pokeher878787: folds 
+scra88le56: raises 445 to 2713 and is all-in
+winghymliu: calls 445
+*** RIVER *** [8s 9s 2c 3s] [As]
+*** SHOW DOWN ***
+scra88le56: shows [Tc 8d] (a pair of Eights)
+winghymliu: shows [6s 4s] (a flush, Ace high)
+winghymliu collected 7396 from pot
+*** SUMMARY ***
+Total pot 7826 | Rake 430 
+Board [8s 9s 2c 3s As]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 (button) folded on the Turn
+Seat 5: scra88le56 (small blind) showed [Tc 8d] and lost with a pair of Eights
+Seat 8: winghymliu (big blind) showed [6s 4s] and won (7396) with a flush, Ace high
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211259841245: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 20:47:40 WET [2020/04/03 15:47:40 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (18959 in chips) 
+Seat 4: pokeher878787 (15929 in chips) 
+Seat 8: winghymliu (12383 in chips) 
+Seat 9: no1beyondfan888 (9239 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [7s Js]
+pokeher878787: raises 200 to 300
+winghymliu has timed out
+winghymliu: folds 
+no1beyondfan888: calls 250
+hellokwanny: calls 200
+*** FLOP *** [6h 3d 4d]
+no1beyondfan888: bets 100
+hellokwanny: folds 
+pokeher878787: raises 525 to 625
+no1beyondfan888: calls 525
+*** TURN *** [6h 3d 4d] [Ah]
+no1beyondfan888: checks 
+pokeher878787: bets 1016
+no1beyondfan888: calls 1016
+*** RIVER *** [6h 3d 4d Ah] [5s]
+no1beyondfan888: checks 
+pokeher878787: bets 1976
+no1beyondfan888: calls 1976
+*** SHOW DOWN ***
+pokeher878787: shows [Qh Qs] (a pair of Queens)
+no1beyondfan888: shows [Tc Ad] (a pair of Aces)
+no1beyondfan888 collected 7687 from pot
+*** SUMMARY ***
+Total pot 8134 | Rake 447 
+Board [6h 3d 4d Ah 5s]
+Seat 1: hellokwanny (big blind) folded on the Flop
+Seat 4: pokeher878787 showed [Qh Qs] and lost with a pair of Queens
+Seat 8: winghymliu (button) folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 (small blind) showed [Tc Ad] and won (7687) with a pair of Aces
+
+
+
+PokerStars Home Game Hand #211259957157: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 20:49:03 WET [2020/04/03 15:49:03 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (18659 in chips) 
+Seat 4: pokeher878787 (12012 in chips) 
+Seat 5: scra88le56 (10000 in chips) 
+Seat 8: winghymliu (12383 in chips) 
+Seat 9: no1beyondfan888 (13009 in chips) 
+hellokwanny: posts small blind 50
+pokeher878787: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [7d Qc]
+scra88le56: folds 
+winghymliu: raises 600 to 700
+no1beyondfan888: calls 700
+hellokwanny: folds 
+pokeher878787: calls 600
+*** FLOP *** [Kc Qd 3c]
+pokeher878787: checks 
+winghymliu: bets 2032
+no1beyondfan888: calls 2032
+pokeher878787: folds 
+*** TURN *** [Kc Qd 3c] [Kd]
+winghymliu: bets 5872
+no1beyondfan888: raises 4405 to 10277 and is all-in
+winghymliu: calls 3779 and is all-in
+Uncalled bet (626) returned to no1beyondfan888
+*** RIVER *** [Kc Qd 3c Kd] [4h]
+*** SHOW DOWN ***
+winghymliu: shows [3d 3s] (a full house, Threes full of Kings)
+no1beyondfan888: shows [Js Kh] (three of a kind, Kings)
+winghymliu collected 24113 from pot
+*** SUMMARY ***
+Total pot 25516 | Rake 1403 
+Board [Kc Qd 3c Kd 4h]
+Seat 1: hellokwanny (small blind) folded before Flop
+Seat 4: pokeher878787 (big blind) folded on the Flop
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 8: winghymliu showed [3d 3s] and won (24113) with a full house, Threes full of Kings
+Seat 9: no1beyondfan888 (button) showed [Js Kh] and lost with three of a kind, Kings
+
+
+
+PokerStars Home Game Hand #211260084946: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 20:50:32 WET [2020/04/03 15:50:32 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (18609 in chips) 
+Seat 4: pokeher878787 (11312 in chips) 
+Seat 5: scra88le56 (10000 in chips) 
+Seat 8: winghymliu (24113 in chips) 
+Seat 9: no1beyondfan888 (626 in chips) 
+pokeher878787: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [8h 5h]
+winghymliu: raises 250 to 350
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: folds 
+scra88le56: calls 250
+*** FLOP *** [6d 3h 7d]
+scra88le56: bets 400
+winghymliu: raises 2600 to 3000
+scra88le56: folds 
+Uncalled bet (2600) returned to winghymliu
+winghymliu collected 1465 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 1550 | Rake 85 
+Board [6d 3h 7d]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 4: pokeher878787 (small blind) folded before Flop
+Seat 5: scra88le56 (big blind) folded on the Flop
+Seat 8: winghymliu collected (1465)
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211260149187: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 20:51:18 WET [2020/04/03 15:51:18 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #4 is the button
+Seat 1: hellokwanny (18609 in chips) 
+Seat 4: pokeher878787 (11262 in chips) 
+Seat 5: scra88le56 (9250 in chips) 
+Seat 8: winghymliu (24828 in chips) 
+Seat 9: no1beyondfan888 (626 in chips) 
+scra88le56: posts small blind 50
+winghymliu: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [As 8d]
+no1beyondfan888: raises 526 to 626 and is all-in
+hellokwanny: calls 626
+pokeher878787: folds 
+scra88le56: folds 
+winghymliu: folds 
+*** FLOP *** [6h 6s 3s]
+*** TURN *** [6h 6s 3s] [Kd]
+*** RIVER *** [6h 6s 3s Kd] [Kc]
+*** SHOW DOWN ***
+no1beyondfan888: shows [9d Ad] (two pair, Kings and Sixes)
+hellokwanny: shows [As 8d] (two pair, Kings and Sixes)
+no1beyondfan888 collected 663 from pot
+hellokwanny collected 662 from pot
+*** SUMMARY ***
+Total pot 1402 | Rake 77 
+Board [6h 6s 3s Kd Kc]
+Seat 1: hellokwanny showed [As 8d] and won (662) with two pair, Kings and Sixes
+Seat 4: pokeher878787 (button) folded before Flop (didn't bet)
+Seat 5: scra88le56 (small blind) folded before Flop
+Seat 8: winghymliu (big blind) folded before Flop
+Seat 9: no1beyondfan888 showed [9d Ad] and won (663) with two pair, Kings and Sixes
+
+
+
+PokerStars Home Game Hand #211260189373: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 20:51:47 WET [2020/04/03 15:51:47 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (18645 in chips) 
+Seat 4: pokeher878787 (11262 in chips) 
+Seat 5: scra88le56 (9200 in chips) 
+Seat 8: winghymliu (24728 in chips) 
+Seat 9: no1beyondfan888 (663 in chips) 
+winghymliu: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [7h 8d]
+hellokwanny: calls 100
+pokeher878787: calls 100
+scra88le56: raises 500 to 600
+winghymliu: folds 
+no1beyondfan888: raises 63 to 663 and is all-in
+hellokwanny: folds 
+pokeher878787: calls 563
+scra88le56: calls 63
+*** FLOP *** [Jc 2d Jd]
+pokeher878787: bets 2021
+scra88le56: raises 6516 to 8537 and is all-in
+pokeher878787: calls 6516
+*** TURN *** [Jc 2d Jd] [9s]
+*** RIVER *** [Jc 2d Jd 9s] [3d]
+*** SHOW DOWN ***
+pokeher878787: shows [Jh 6h] (three of a kind, Jacks)
+scra88le56: shows [Kh Ks] (two pair, Kings and Jacks)
+pokeher878787 collected 16135 from side pot
+no1beyondfan888: shows [Ts Qs] (a pair of Jacks)
+pokeher878787 collected 2021 from main pot
+*** SUMMARY ***
+Total pot 19213 Main pot 2021. Side pot 16135. | Rake 1057 
+Board [Jc 2d Jd 9s 3d]
+Seat 1: hellokwanny folded before Flop
+Seat 4: pokeher878787 showed [Jh 6h] and won (18156) with three of a kind, Jacks
+Seat 5: scra88le56 (button) showed [Kh Ks] and lost with two pair, Kings and Jacks
+Seat 8: winghymliu (small blind) folded before Flop
+Seat 9: no1beyondfan888 (big blind) showed [Ts Qs] and lost with a pair of Jacks
+
+
+
+PokerStars Home Game Hand #211260279730: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 20:52:52 WET [2020/04/03 15:52:52 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (18545 in chips) 
+Seat 4: pokeher878787 (20218 in chips) 
+Seat 8: winghymliu (24678 in chips) 
+hellokwanny: posts small blind 50
+pokeher878787: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [3d Tc]
+winghymliu: calls 100
+hellokwanny: folds 
+pokeher878787: checks 
+*** FLOP *** [Qs 5c Qd]
+pokeher878787: bets 118
+winghymliu: raises 472 to 590
+pokeher878787: calls 472
+*** TURN *** [Qs 5c Qd] [8h]
+pokeher878787: bets 675
+winghymliu: calls 675
+*** RIVER *** [Qs 5c Qd 8h] [Jc]
+pokeher878787: bets 1313
+winghymliu: folds 
+Uncalled bet (1313) returned to pokeher878787
+pokeher878787 collected 2627 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 2780 | Rake 153 
+Board [Qs 5c Qd 8h Jc]
+Seat 1: hellokwanny (small blind) folded before Flop
+Seat 4: pokeher878787 (big blind) collected (2627)
+Seat 8: winghymliu (button) folded on the River
+
+
+
+PokerStars Home Game Hand #211260375963: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 20:53:56 WET [2020/04/03 15:53:56 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (18495 in chips) 
+Seat 4: pokeher878787 (21480 in chips) 
+Seat 5: scra88le56 (10000 in chips) 
+Seat 8: winghymliu (23313 in chips) 
+Seat 9: no1beyondfan888 (10000 in chips) 
+pokeher878787: posts small blind 50
+scra88le56: posts big blind 100
+no1beyondfan888: posts small blind 50
+*** HOLE CARDS ***
+Dealt to hellokwanny [6c 9h]
+winghymliu: folds 
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: raises 200 to 300
+scra88le56: calls 200
+*** FLOP *** [2d 6d Qh]
+pokeher878787: bets 307
+scra88le56: folds 
+Uncalled bet (307) returned to pokeher878787
+pokeher878787 collected 614 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 650 | Rake 36 
+Board [2d 6d Qh]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 4: pokeher878787 (small blind) collected (614)
+Seat 5: scra88le56 (big blind) folded on the Flop
+Seat 8: winghymliu folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211260420037: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 20:54:27 WET [2020/04/03 15:54:27 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #4 is the button
+Seat 1: hellokwanny (18495 in chips) 
+Seat 4: pokeher878787 (21794 in chips) 
+Seat 5: scra88le56 (9700 in chips) 
+Seat 8: winghymliu (23313 in chips) 
+Seat 9: no1beyondfan888 (9950 in chips) 
+scra88le56: posts small blind 50
+winghymliu: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [6c 6d]
+no1beyondfan888: folds 
+hellokwanny: calls 100
+pokeher878787: calls 100
+scra88le56: folds 
+winghymliu: raises 300 to 400
+hellokwanny: calls 300
+pokeher878787: calls 300
+*** FLOP *** [Jc 9c As]
+winghymliu: checks 
+hellokwanny: checks 
+pokeher878787: bets 590
+winghymliu: calls 590
+hellokwanny: folds 
+*** TURN *** [Jc 9c As] [Ad]
+winghymliu: checks 
+pokeher878787: bets 1148
+winghymliu: calls 1148
+*** RIVER *** [Jc 9c As Ad] [3d]
+winghymliu: bets 100
+pokeher878787: calls 100
+*** SHOW DOWN ***
+winghymliu: shows [Kd Qd] (a pair of Aces)
+pokeher878787: mucks hand 
+winghymliu collected 4655 from pot
+*** SUMMARY ***
+Total pot 4926 | Rake 271 
+Board [Jc 9c As Ad 3d]
+Seat 1: hellokwanny folded on the Flop
+Seat 4: pokeher878787 (button) mucked [8h 7s]
+Seat 5: scra88le56 (small blind) folded before Flop
+Seat 8: winghymliu (big blind) showed [Kd Qd] and won (4655) with a pair of Aces
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211260512879: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 20:55:51 WET [2020/04/03 15:55:51 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (18095 in chips) 
+Seat 4: pokeher878787 (19556 in chips) 
+Seat 5: scra88le56 (9650 in chips) 
+Seat 8: winghymliu (25730 in chips) 
+Seat 9: no1beyondfan888 (9950 in chips) 
+winghymliu: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [3c 4h]
+hellokwanny: folds 
+pokeher878787: calls 100
+scra88le56: raises 1200 to 1300
+winghymliu: folds 
+no1beyondfan888: folds 
+pokeher878787: folds 
+Uncalled bet (1200) returned to scra88le56
+scra88le56 collected 350 from pot
+scra88le56: doesn't show hand 
+*** SUMMARY ***
+Total pot 350 | Rake 0 
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 folded before Flop
+Seat 5: scra88le56 (button) collected (350)
+Seat 8: winghymliu (small blind) folded before Flop
+Seat 9: no1beyondfan888 (big blind) folded before Flop
+
+
+
+PokerStars Home Game Hand #211260535049: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 20:56:14 WET [2020/04/03 15:56:14 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (18095 in chips) 
+Seat 4: pokeher878787 (19456 in chips) 
+Seat 5: scra88le56 (9900 in chips) 
+Seat 8: winghymliu (25680 in chips) 
+Seat 9: no1beyondfan888 (9850 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [9s 7c]
+pokeher878787: calls 100
+scra88le56: folds 
+winghymliu: folds 
+no1beyondfan888: calls 50
+hellokwanny: checks 
+*** FLOP *** [6s Qs 3s]
+no1beyondfan888: checks 
+hellokwanny: checks 
+pokeher878787: bets 141
+no1beyondfan888: folds 
+hellokwanny: folds 
+Uncalled bet (141) returned to pokeher878787
+pokeher878787 collected 283 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 300 | Rake 17 
+Board [6s Qs 3s]
+Seat 1: hellokwanny (big blind) folded on the Flop
+Seat 4: pokeher878787 collected (283)
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 8: winghymliu (button) folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 (small blind) folded on the Flop
+
+
+
+PokerStars Home Game Hand #211260566801: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 20:56:47 WET [2020/04/03 15:56:47 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (17995 in chips) 
+Seat 4: pokeher878787 (19639 in chips) 
+Seat 5: scra88le56 (9900 in chips) 
+Seat 8: winghymliu (25680 in chips) 
+Seat 9: no1beyondfan888 (9750 in chips) 
+hellokwanny: posts small blind 50
+pokeher878787: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [6c 6s]
+scra88le56: folds 
+winghymliu: folds 
+no1beyondfan888: calls 100
+hellokwanny: calls 50
+pokeher878787: checks 
+*** FLOP *** [Qd 6h As]
+hellokwanny: checks 
+pokeher878787: bets 141
+no1beyondfan888: calls 141
+hellokwanny: calls 141
+*** TURN *** [Qd 6h As] [3h]
+hellokwanny: checks 
+pokeher878787: bets 100
+no1beyondfan888: calls 100
+hellokwanny: raises 300 to 400
+pokeher878787: folds 
+no1beyondfan888: calls 300
+*** RIVER *** [Qd 6h As 3h] [2h]
+hellokwanny: bets 1022
+no1beyondfan888: folds 
+Uncalled bet (1022) returned to hellokwanny
+hellokwanny collected 1534 from pot
+hellokwanny: doesn't show hand 
+*** SUMMARY ***
+Total pot 1623 | Rake 89 
+Board [Qd 6h As 3h 2h]
+Seat 1: hellokwanny (small blind) collected (1534)
+Seat 4: pokeher878787 (big blind) folded on the Turn
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 8: winghymliu folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 (button) folded on the River
+
+
+
+PokerStars Home Game Hand #211260622953: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 20:57:42 WET [2020/04/03 15:57:42 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (18888 in chips) 
+Seat 4: pokeher878787 (19298 in chips) 
+Seat 5: scra88le56 (9900 in chips) 
+Seat 8: winghymliu (25680 in chips) 
+Seat 9: no1beyondfan888 (9109 in chips) 
+pokeher878787: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [7d 9c]
+winghymliu: folds 
+no1beyondfan888: calls 100
+hellokwanny: folds 
+pokeher878787: calls 50
+scra88le56: raises 100 to 200
+no1beyondfan888: calls 100
+pokeher878787: calls 100
+*** FLOP *** [8d 3h 5h]
+pokeher878787: bets 283
+scra88le56: raises 1133 to 1416
+no1beyondfan888: raises 1133 to 2549
+pokeher878787: raises 16549 to 19098 and is all-in
+scra88le56: calls 8284 and is all-in
+no1beyondfan888: calls 6360 and is all-in
+Uncalled bet (9398) returned to pokeher878787
+*** TURN *** [8d 3h 5h] [Jd]
+*** RIVER *** [8d 3h 5h Jd] [7h]
+*** SHOW DOWN ***
+pokeher878787: shows [8s Js] (two pair, Jacks and Eights)
+scra88le56: shows [Ac Ah] (a pair of Aces)
+pokeher878787 collected 1495 from side pot
+no1beyondfan888: shows [8h 8c] (three of a kind, Eights)
+no1beyondfan888 collected 25824 from main pot
+*** SUMMARY ***
+Total pot 28909 Main pot 25824. Side pot 1495. | Rake 1590 
+Board [8d 3h 5h Jd 7h]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 4: pokeher878787 (small blind) showed [8s Js] and won (1495) with two pair, Jacks and Eights
+Seat 5: scra88le56 (big blind) showed [Ac Ah] and lost with a pair of Aces
+Seat 8: winghymliu folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 showed [8h 8c] and won (25824) with three of a kind, Eights
+
+
+
+PokerStars Home Game Hand #211260682997: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 20:58:43 WET [2020/04/03 15:58:43 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #4 is the button
+Seat 1: hellokwanny (18888 in chips) 
+Seat 4: pokeher878787 (10893 in chips) 
+Seat 8: winghymliu (25680 in chips) 
+Seat 9: no1beyondfan888 (25824 in chips) 
+winghymliu: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [8h Jd]
+hellokwanny: folds 
+pokeher878787: calls 100
+winghymliu: folds 
+no1beyondfan888: checks 
+*** FLOP *** [Ts Qh 9d]
+no1beyondfan888: checks 
+pokeher878787: checks 
+*** TURN *** [Ts Qh 9d] [6h]
+no1beyondfan888: checks 
+pokeher878787: checks 
+*** RIVER *** [Ts Qh 9d 6h] [8s]
+no1beyondfan888: bets 236
+pokeher878787: calls 236
+*** SHOW DOWN ***
+no1beyondfan888: shows [7s 2d] (a straight, Six to Ten)
+pokeher878787: mucks hand 
+no1beyondfan888 collected 682 from pot
+*** SUMMARY ***
+Total pot 722 | Rake 40 
+Board [Ts Qh 9d 6h 8s]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 (button) mucked [8c 3h]
+Seat 8: winghymliu (small blind) folded before Flop
+Seat 9: no1beyondfan888 (big blind) showed [7s 2d] and won (682) with a straight, Six to Ten
+
+
+
+PokerStars Home Game Hand #211260732188: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 20:59:35 WET [2020/04/03 15:59:35 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (18888 in chips) 
+Seat 4: pokeher878787 (10557 in chips) 
+Seat 5: scra88le56 (10000 in chips) 
+Seat 8: winghymliu (25630 in chips) 
+Seat 9: no1beyondfan888 (26170 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+scra88le56: posts small blind 50
+*** HOLE CARDS ***
+Dealt to hellokwanny [Ts Js]
+pokeher878787: raises 200 to 300
+scra88le56: folds 
+winghymliu: calls 300
+no1beyondfan888: calls 250
+hellokwanny: calls 200
+*** FLOP *** [4s Qc 7s]
+no1beyondfan888: bets 100
+hellokwanny: calls 100
+pokeher878787: calls 100
+winghymliu: raises 1581 to 1681
+no1beyondfan888: folds 
+hellokwanny: calls 1581
+pokeher878787: folds 
+*** TURN *** [4s Qc 7s] [4d]
+hellokwanny: checks 
+winghymliu: bets 23649 and is all-in
+hellokwanny: folds 
+Uncalled bet (23649) returned to winghymliu
+winghymliu collected 4547 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 4812 | Rake 265 
+Board [4s Qc 7s 4d]
+Seat 1: hellokwanny (big blind) folded on the Turn
+Seat 4: pokeher878787 folded on the Flop
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 8: winghymliu (button) collected (4547)
+Seat 9: no1beyondfan888 (small blind) folded on the Flop
+
+
+
+PokerStars Home Game Hand #211260814998: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:00:51 WET [2020/04/03 16:00:51 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (16907 in chips) 
+Seat 4: pokeher878787 (10157 in chips) 
+Seat 5: scra88le56 (9950 in chips) 
+Seat 8: winghymliu (28196 in chips) 
+Seat 9: no1beyondfan888 (25770 in chips) 
+hellokwanny: posts small blind 50
+pokeher878787: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Ad 3c]
+scra88le56: raises 500 to 600
+winghymliu: folds 
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: folds 
+Uncalled bet (500) returned to scra88le56
+scra88le56 collected 250 from pot
+scra88le56: doesn't show hand 
+*** SUMMARY ***
+Total pot 250 | Rake 0 
+Seat 1: hellokwanny (small blind) folded before Flop
+Seat 4: pokeher878787 (big blind) folded before Flop
+Seat 5: scra88le56 collected (250)
+Seat 8: winghymliu folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 (button) folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211260838019: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:01:10 WET [2020/04/03 16:01:10 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (16857 in chips) 
+Seat 4: pokeher878787 (10057 in chips) 
+Seat 5: scra88le56 (10100 in chips) 
+Seat 8: winghymliu (28196 in chips) 
+Seat 9: no1beyondfan888 (25770 in chips) 
+pokeher878787: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [4c Ks]
+winghymliu: calls 100
+no1beyondfan888: calls 100
+hellokwanny: folds 
+pokeher878787: calls 50
+scra88le56: checks 
+*** FLOP *** [Ad 7s 3h]
+pokeher878787: checks 
+scra88le56: checks 
+winghymliu: checks 
+no1beyondfan888: bets 189
+pokeher878787: calls 189
+scra88le56: folds 
+winghymliu: folds 
+*** TURN *** [Ad 7s 3h] [4s]
+pokeher878787: checks 
+no1beyondfan888: checks 
+*** RIVER *** [Ad 7s 3h 4s] [3s]
+pokeher878787: checks 
+no1beyondfan888: bets 735
+pokeher878787: folds 
+Uncalled bet (735) returned to no1beyondfan888
+no1beyondfan888 collected 735 from pot
+no1beyondfan888: doesn't show hand 
+*** SUMMARY ***
+Total pot 778 | Rake 43 
+Board [Ad 7s 3h 4s 3s]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 4: pokeher878787 (small blind) folded on the River
+Seat 5: scra88le56 (big blind) folded on the Flop
+Seat 8: winghymliu folded on the Flop
+Seat 9: no1beyondfan888 collected (735)
+
+
+
+PokerStars Home Game Hand #211260904594: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:02:03 WET [2020/04/03 16:02:03 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #4 is the button
+Seat 1: hellokwanny (16857 in chips) 
+Seat 4: pokeher878787 (9768 in chips) 
+Seat 5: scra88le56 (10000 in chips) 
+Seat 8: winghymliu (28096 in chips) 
+Seat 9: no1beyondfan888 (26216 in chips) 
+scra88le56: posts small blind 50
+winghymliu: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [9c Td]
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: calls 100
+scra88le56: calls 50
+winghymliu: checks 
+*** FLOP *** [3c As Ks]
+scra88le56: checks 
+winghymliu: bets 283
+pokeher878787: folds 
+scra88le56: folds 
+Uncalled bet (283) returned to winghymliu
+winghymliu collected 283 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 300 | Rake 17 
+Board [3c As Ks]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 (button) folded on the Flop
+Seat 5: scra88le56 (small blind) folded on the Flop
+Seat 8: winghymliu (big blind) collected (283)
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211260938427: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:02:28 WET [2020/04/03 16:02:28 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (16857 in chips) 
+Seat 4: pokeher878787 (9668 in chips) 
+Seat 5: scra88le56 (9900 in chips) 
+Seat 8: winghymliu (28279 in chips) 
+Seat 9: no1beyondfan888 (26216 in chips) 
+winghymliu: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [8s 6d]
+hellokwanny: folds 
+pokeher878787: raises 200 to 300
+scra88le56: folds 
+winghymliu: calls 250
+no1beyondfan888: calls 200
+*** FLOP *** [5d Kh Ks]
+winghymliu: bets 100
+no1beyondfan888: raises 525 to 625
+pokeher878787: folds 
+winghymliu: folds 
+Uncalled bet (525) returned to no1beyondfan888
+no1beyondfan888 collected 1039 from pot
+no1beyondfan888: doesn't show hand 
+*** SUMMARY ***
+Total pot 1100 | Rake 61 
+Board [5d Kh Ks]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 folded on the Flop
+Seat 5: scra88le56 (button) folded before Flop (didn't bet)
+Seat 8: winghymliu (small blind) folded on the Flop
+Seat 9: no1beyondfan888 (big blind) collected (1039)
+
+
+
+PokerStars Home Game Hand #211261003748: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:03:16 WET [2020/04/03 16:03:16 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (16857 in chips) 
+Seat 4: pokeher878787 (9368 in chips) 
+Seat 5: scra88le56 (9900 in chips) 
+Seat 8: winghymliu (27879 in chips) 
+Seat 9: no1beyondfan888 (26855 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [2s 6h]
+pokeher878787: calls 100
+scra88le56: folds 
+winghymliu: calls 100
+no1beyondfan888: folds 
+hellokwanny: checks 
+*** FLOP *** [Qd 5s Kd]
+hellokwanny: checks 
+pokeher878787: checks 
+winghymliu: bets 700
+hellokwanny: folds 
+pokeher878787: folds 
+Uncalled bet (700) returned to winghymliu
+winghymliu collected 331 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 350 | Rake 19 
+Board [Qd 5s Kd]
+Seat 1: hellokwanny (big blind) folded on the Flop
+Seat 4: pokeher878787 folded on the Flop
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 8: winghymliu (button) collected (331)
+Seat 9: no1beyondfan888 (small blind) folded before Flop
+
+
+
+PokerStars Home Game Hand #211261053660: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:03:51 WET [2020/04/03 16:03:51 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (16757 in chips) 
+Seat 4: pokeher878787 (9268 in chips) 
+Seat 5: scra88le56 (9900 in chips) 
+Seat 8: winghymliu (28110 in chips) 
+Seat 9: no1beyondfan888 (26805 in chips) 
+hellokwanny: posts small blind 50
+pokeher878787: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Kh 8c]
+scra88le56: raises 700 to 800
+winghymliu: raises 1750 to 2550
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: folds 
+scra88le56: raises 7350 to 9900 and is all-in
+winghymliu: calls 7350
+*** FLOP *** [Qc 9s Th]
+*** TURN *** [Qc 9s Th] [9d]
+*** RIVER *** [Qc 9s Th 9d] [Ah]
+*** SHOW DOWN ***
+scra88le56: shows [Kc Ks] (two pair, Kings and Nines)
+winghymliu: shows [8d 8s] (two pair, Nines and Eights)
+scra88le56 collected 18853 from pot
+*** SUMMARY ***
+Total pot 19950 | Rake 1097 
+Board [Qc 9s Th 9d Ah]
+Seat 1: hellokwanny (small blind) folded before Flop
+Seat 4: pokeher878787 (big blind) folded before Flop
+Seat 5: scra88le56 showed [Kc Ks] and won (18853) with two pair, Kings and Nines
+Seat 8: winghymliu showed [8d 8s] and lost with two pair, Nines and Eights
+Seat 9: no1beyondfan888 (button) folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211261101178: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:04:17 WET [2020/04/03 16:04:17 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (16707 in chips) 
+Seat 4: pokeher878787 (9168 in chips) 
+Seat 5: scra88le56 (18853 in chips) 
+Seat 8: winghymliu (18210 in chips) 
+Seat 9: no1beyondfan888 (26805 in chips) 
+pokeher878787: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [6d 9c]
+winghymliu: calls 100
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: calls 50
+scra88le56: checks 
+*** FLOP *** [8s Jc 2c]
+pokeher878787: checks 
+scra88le56: checks 
+winghymliu: bets 283
+pokeher878787: folds 
+scra88le56: calls 283
+*** TURN *** [8s Jc 2c] [Ad]
+scra88le56: checks 
+winghymliu: bets 818
+scra88le56: calls 818
+*** RIVER *** [8s Jc 2c Ad] [8d]
+scra88le56: checks 
+winghymliu: bets 17009 and is all-in
+scra88le56: folds 
+Uncalled bet (17009) returned to winghymliu
+winghymliu collected 2364 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 2502 | Rake 138 
+Board [8s Jc 2c Ad 8d]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 4: pokeher878787 (small blind) folded on the Flop
+Seat 5: scra88le56 (big blind) folded on the River
+Seat 8: winghymliu collected (2364)
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211261196788: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:05:24 WET [2020/04/03 16:05:24 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #4 is the button
+Seat 1: hellokwanny (16707 in chips) 
+Seat 4: pokeher878787 (9068 in chips) 
+Seat 5: scra88le56 (17652 in chips) 
+Seat 8: winghymliu (19373 in chips) 
+Seat 9: no1beyondfan888 (26805 in chips) 
+scra88le56: posts small blind 50
+winghymliu: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Tc 8s]
+no1beyondfan888: calls 100
+hellokwanny: folds 
+pokeher878787: calls 100
+scra88le56: calls 50
+winghymliu: checks 
+*** FLOP *** [2d 7s Js]
+scra88le56: bets 189
+winghymliu: folds 
+no1beyondfan888: folds 
+pokeher878787: raises 189 to 378
+scra88le56: calls 189
+*** TURN *** [2d 7s Js] [7h]
+scra88le56: bets 546
+pokeher878787: calls 546
+*** RIVER *** [2d 7s Js 7h] [9s]
+scra88le56: bets 16628 and is all-in
+pokeher878787: folds 
+Uncalled bet (16628) returned to scra88le56
+scra88le56 collected 2124 from pot
+scra88le56: doesn't show hand 
+*** SUMMARY ***
+Total pot 2248 | Rake 124 
+Board [2d 7s Js 7h 9s]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 (button) folded on the River
+Seat 5: scra88le56 (small blind) collected (2124)
+Seat 8: winghymliu (big blind) folded on the Flop
+Seat 9: no1beyondfan888 folded on the Flop
+
+
+
+PokerStars Home Game Hand #211261305883: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:06:41 WET [2020/04/03 16:06:41 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (16707 in chips) 
+Seat 4: pokeher878787 (8044 in chips) 
+Seat 5: scra88le56 (18752 in chips) 
+Seat 8: winghymliu (19273 in chips) 
+Seat 9: no1beyondfan888 (26705 in chips) 
+winghymliu: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Ah Th]
+hellokwanny: raises 300 to 400
+pokeher878787: folds 
+scra88le56: calls 400
+winghymliu: calls 350
+no1beyondfan888: calls 300
+*** FLOP *** [Kd 5c 8c]
+winghymliu: checks 
+no1beyondfan888: checks 
+hellokwanny: bets 756
+scra88le56: raises 756 to 1512
+winghymliu: folds 
+no1beyondfan888: folds 
+hellokwanny: folds 
+Uncalled bet (756) returned to scra88le56
+scra88le56 collected 2941 from pot
+scra88le56: doesn't show hand 
+*** SUMMARY ***
+Total pot 3112 | Rake 171 
+Board [Kd 5c 8c]
+Seat 1: hellokwanny folded on the Flop
+Seat 4: pokeher878787 folded before Flop (didn't bet)
+Seat 5: scra88le56 (button) collected (2941)
+Seat 8: winghymliu (small blind) folded on the Flop
+Seat 9: no1beyondfan888 (big blind) folded on the Flop
+
+
+
+PokerStars Home Game Hand #211261372991: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:07:29 WET [2020/04/03 16:07:29 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (15551 in chips) 
+Seat 4: pokeher878787 (8044 in chips) 
+Seat 5: scra88le56 (20537 in chips) 
+Seat 8: winghymliu (18873 in chips) 
+Seat 9: no1beyondfan888 (26305 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Td 8h]
+pokeher878787: raises 200 to 300
+scra88le56: raises 500 to 800
+winghymliu: folds 
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: raises 500 to 1300
+scra88le56: raises 19237 to 20537 and is all-in
+pokeher878787: calls 6744 and is all-in
+Uncalled bet (12493) returned to scra88le56
+*** FLOP *** [6s Kh 8c]
+*** TURN *** [6s Kh 8c] [Jd]
+*** RIVER *** [6s Kh 8c Jd] [7s]
+*** SHOW DOWN ***
+pokeher878787: shows [Kd Jc] (two pair, Kings and Jacks)
+scra88le56: shows [9d 9c] (a pair of Nines)
+pokeher878787 collected 15345 from pot
+*** SUMMARY ***
+Total pot 16238 | Rake 893 
+Board [6s Kh 8c Jd 7s]
+Seat 1: hellokwanny (big blind) folded before Flop
+Seat 4: pokeher878787 showed [Kd Jc] and won (15345) with two pair, Kings and Jacks
+Seat 5: scra88le56 showed [9d 9c] and lost with a pair of Nines
+Seat 8: winghymliu (button) folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 (small blind) folded before Flop
+
+
+
+PokerStars Home Game Hand #211261428872: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:08:08 WET [2020/04/03 16:08:08 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (15451 in chips) 
+Seat 4: pokeher878787 (15345 in chips) 
+Seat 5: scra88le56 (12493 in chips) 
+Seat 8: winghymliu (18873 in chips) 
+Seat 9: no1beyondfan888 (26255 in chips) 
+hellokwanny: posts small blind 50
+pokeher878787: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Qc Th]
+scra88le56: folds 
+winghymliu: calls 100
+no1beyondfan888: calls 100
+hellokwanny: raises 200 to 300
+pokeher878787: calls 200
+winghymliu: calls 200
+no1beyondfan888: calls 200
+*** FLOP *** [Kd Jh Ks]
+hellokwanny: bets 567
+pokeher878787: folds 
+winghymliu: folds 
+no1beyondfan888: calls 567
+*** TURN *** [Kd Jh Ks] [5s]
+hellokwanny: bets 1103
+no1beyondfan888: calls 1103
+*** RIVER *** [Kd Jh Ks 5s] [Qs]
+hellokwanny: checks 
+no1beyondfan888: bets 4290
+hellokwanny: calls 4290
+*** SHOW DOWN ***
+no1beyondfan888: shows [3h Kc] (three of a kind, Kings)
+hellokwanny: mucks hand 
+no1beyondfan888 collected 12398 from pot
+*** SUMMARY ***
+Total pot 13120 | Rake 722 
+Board [Kd Jh Ks 5s Qs]
+Seat 1: hellokwanny (small blind) mucked [Qc Th]
+Seat 4: pokeher878787 (big blind) folded on the Flop
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 8: winghymliu folded on the Flop
+Seat 9: no1beyondfan888 (button) showed [3h Kc] and won (12398) with three of a kind, Kings
+
+
+
+PokerStars Home Game Hand #211261541497: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:09:28 WET [2020/04/03 16:09:28 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (9191 in chips) 
+Seat 4: pokeher878787 (15045 in chips) 
+Seat 5: scra88le56 (12493 in chips) 
+Seat 8: winghymliu (18573 in chips) 
+Seat 9: no1beyondfan888 (32393 in chips) 
+pokeher878787: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [5c 6h]
+winghymliu: calls 100
+no1beyondfan888: calls 100
+hellokwanny: folds 
+pokeher878787: raises 200 to 300
+scra88le56: raises 200 to 500
+winghymliu: folds 
+no1beyondfan888: calls 400
+pokeher878787: raises 200 to 700
+scra88le56: calls 200
+no1beyondfan888: calls 200
+*** FLOP *** [4d 3s Qs]
+pokeher878787: bets 100
+scra88le56: raises 800 to 900
+no1beyondfan888: folds 
+pokeher878787: raises 800 to 1700
+scra88le56: raises 10093 to 11793 and is all-in
+pokeher878787: folds 
+Uncalled bet (10093) returned to scra88le56
+scra88le56 collected 5292 from pot
+scra88le56: doesn't show hand 
+*** SUMMARY ***
+Total pot 5600 | Rake 308 
+Board [4d 3s Qs]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 4: pokeher878787 (small blind) folded on the Flop
+Seat 5: scra88le56 (big blind) collected (5292)
+Seat 8: winghymliu folded before Flop
+Seat 9: no1beyondfan888 folded on the Flop
+
+
+
+PokerStars Home Game Hand #211261665705: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:10:58 WET [2020/04/03 16:10:58 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #4 is the button
+Seat 1: hellokwanny (9191 in chips) 
+Seat 4: pokeher878787 (12645 in chips) 
+Seat 5: scra88le56 (15385 in chips) 
+Seat 8: winghymliu (18473 in chips) 
+Seat 9: no1beyondfan888 (31693 in chips) 
+scra88le56: posts small blind 50
+winghymliu: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Jc 9d]
+no1beyondfan888: raises 100 to 200
+hellokwanny: calls 200
+pokeher878787: raises 100 to 300
+scra88le56: calls 250
+winghymliu: calls 200
+no1beyondfan888: calls 100
+hellokwanny: calls 100
+*** FLOP *** [4s 4c Td]
+scra88le56: checks 
+winghymliu: checks 
+no1beyondfan888: checks 
+hellokwanny: checks 
+pokeher878787: bets 1417
+scra88le56: folds 
+winghymliu: folds 
+no1beyondfan888: folds 
+hellokwanny: folds 
+Uncalled bet (1417) returned to pokeher878787
+pokeher878787 collected 1417 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 1500 | Rake 83 
+Board [4s 4c Td]
+Seat 1: hellokwanny folded on the Flop
+Seat 4: pokeher878787 (button) collected (1417)
+Seat 5: scra88le56 (small blind) folded on the Flop
+Seat 8: winghymliu (big blind) folded on the Flop
+Seat 9: no1beyondfan888 folded on the Flop
+
+
+
+PokerStars Home Game Hand #211261740835: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:11:51 WET [2020/04/03 16:11:51 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (8891 in chips) 
+Seat 4: pokeher878787 (13762 in chips) 
+Seat 5: scra88le56 (15085 in chips) 
+Seat 8: winghymliu (18173 in chips) 
+Seat 9: no1beyondfan888 (31393 in chips) 
+winghymliu: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Th Ks]
+hellokwanny: raises 200 to 300
+pokeher878787: calls 300
+scra88le56: raises 1100 to 1400
+winghymliu: folds 
+no1beyondfan888: folds 
+hellokwanny: calls 1100
+pokeher878787: calls 1100
+*** FLOP *** [2h 7h 6d]
+hellokwanny: checks 
+pokeher878787: checks 
+scra88le56: bets 1500
+hellokwanny: folds 
+pokeher878787: calls 1500
+*** TURN *** [2h 7h 6d] [5h]
+pokeher878787: checks 
+scra88le56: bets 7800
+pokeher878787: folds 
+Uncalled bet (7800) returned to scra88le56
+scra88le56 collected 6946 from pot
+scra88le56: doesn't show hand 
+*** SUMMARY ***
+Total pot 7350 | Rake 404 
+Board [2h 7h 6d 5h]
+Seat 1: hellokwanny folded on the Flop
+Seat 4: pokeher878787 folded on the Turn
+Seat 5: scra88le56 (button) collected (6946)
+Seat 8: winghymliu (small blind) folded before Flop
+Seat 9: no1beyondfan888 (big blind) folded before Flop
+
+
+
+PokerStars Home Game Hand #211261867103: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:13:20 WET [2020/04/03 16:13:20 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (7491 in chips) 
+Seat 4: pokeher878787 (10862 in chips) 
+Seat 5: scra88le56 (19131 in chips) 
+Seat 8: winghymliu (18123 in chips) 
+Seat 9: no1beyondfan888 (31293 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [3h Jc]
+pokeher878787: calls 100
+scra88le56: calls 100
+winghymliu: calls 100
+no1beyondfan888: calls 50
+hellokwanny: checks 
+*** FLOP *** [8h Ts 9h]
+no1beyondfan888: bets 100
+hellokwanny: calls 100
+pokeher878787: raises 386 to 486
+scra88le56: folds 
+winghymliu: folds 
+no1beyondfan888: calls 386
+hellokwanny: calls 386
+*** TURN *** [8h Ts 9h] [7h]
+no1beyondfan888: checks 
+hellokwanny: checks 
+pokeher878787: bets 1850
+no1beyondfan888: raises 28857 to 30707 and is all-in
+hellokwanny: calls 6905 and is all-in
+pokeher878787: folds 
+Uncalled bet (23802) returned to no1beyondfan888
+*** RIVER *** [8h Ts 9h 7h] [Jh]
+*** SHOW DOWN ***
+no1beyondfan888: shows [6h Kh] (a flush, King high)
+hellokwanny: shows [3h Jc] (a flush, Jack high)
+no1beyondfan888 collected 16649 from pot
+*** SUMMARY ***
+Total pot 17618 | Rake 969 
+Board [8h Ts 9h 7h Jh]
+Seat 1: hellokwanny (big blind) showed [3h Jc] and lost with a flush, Jack high
+Seat 4: pokeher878787 folded on the Turn
+Seat 5: scra88le56 folded on the Flop
+Seat 8: winghymliu (button) folded on the Flop
+Seat 9: no1beyondfan888 (small blind) showed [6h Kh] and won (16649) with a flush, King high
+
+
+
+PokerStars Home Game Hand #211262054750: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:15:32 WET [2020/04/03 16:15:32 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #4 is the button
+Seat 1: hellokwanny (10000 in chips) 
+Seat 4: pokeher878787 (8326 in chips) 
+Seat 5: scra88le56 (18931 in chips) 
+Seat 8: winghymliu (18023 in chips) 
+Seat 9: no1beyondfan888 (40634 in chips) 
+scra88le56: posts small blind 50
+winghymliu: posts big blind 100
+hellokwanny: posts small blind 50
+*** HOLE CARDS ***
+Dealt to hellokwanny [8s 2s]
+no1beyondfan888: raises 100 to 200
+hellokwanny: folds 
+pokeher878787: calls 200
+scra88le56: calls 150
+winghymliu: calls 100
+*** FLOP *** [Qs Kd 7c]
+scra88le56: bets 400
+winghymliu: calls 400
+no1beyondfan888: calls 400
+pokeher878787: folds 
+*** TURN *** [Qs Kd 7c] [8d]
+scra88le56: bets 968
+winghymliu: calls 968
+no1beyondfan888: folds 
+*** RIVER *** [Qs Kd 7c 8d] [Jc]
+scra88le56: checks 
+winghymliu: bets 100
+scra88le56: raises 400 to 500
+winghymliu: calls 400
+*** SHOW DOWN ***
+scra88le56: shows [5d Ks] (a pair of Kings)
+winghymliu: mucks hand 
+scra88le56 collected 4712 from pot
+*** SUMMARY ***
+Total pot 4986 | Rake 274 
+Board [Qs Kd 7c 8d Jc]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 (button) folded on the Flop
+Seat 5: scra88le56 (small blind) showed [5d Ks] and won (4712) with a pair of Kings
+Seat 8: winghymliu (big blind) mucked [Qd 3d]
+Seat 9: no1beyondfan888 folded on the Turn
+
+
+
+PokerStars Home Game Hand #211262158184: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:16:43 WET [2020/04/03 16:16:43 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (9950 in chips) 
+Seat 4: pokeher878787 (8126 in chips) 
+Seat 5: scra88le56 (21575 in chips) 
+Seat 8: winghymliu (15955 in chips) 
+Seat 9: no1beyondfan888 (40034 in chips) 
+winghymliu: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [2c Jh]
+hellokwanny: folds 
+pokeher878787: raises 200 to 300
+scra88le56: calls 300
+winghymliu: calls 250
+no1beyondfan888: raises 200 to 500
+pokeher878787: calls 200
+scra88le56: calls 200
+winghymliu: calls 200
+*** FLOP *** [8s 6d Qh]
+winghymliu: checks 
+no1beyondfan888: checks 
+pokeher878787: bets 945
+scra88le56: folds 
+winghymliu: calls 945
+no1beyondfan888: folds 
+*** TURN *** [8s 6d Qh] [6h]
+winghymliu: checks 
+pokeher878787: bets 3676
+winghymliu: folds 
+Uncalled bet (3676) returned to pokeher878787
+pokeher878787 collected 3676 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 3890 | Rake 214 
+Board [8s 6d Qh 6h]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 collected (3676)
+Seat 5: scra88le56 (button) folded on the Flop
+Seat 8: winghymliu (small blind) folded on the Turn
+Seat 9: no1beyondfan888 (big blind) folded on the Flop
+
+
+
+PokerStars Home Game Hand #211262290543: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:18:14 WET [2020/04/03 16:18:14 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (9950 in chips) 
+Seat 4: pokeher878787 (10357 in chips) 
+Seat 5: scra88le56 (21075 in chips) 
+Seat 8: winghymliu (14510 in chips) 
+Seat 9: no1beyondfan888 (39534 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [7s Tc]
+pokeher878787: calls 100
+scra88le56: folds 
+winghymliu: calls 100
+no1beyondfan888: calls 50
+hellokwanny: checks 
+*** FLOP *** [Jd 7c Ac]
+no1beyondfan888: checks 
+hellokwanny: checks 
+pokeher878787: checks 
+winghymliu: bets 378
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: folds 
+Uncalled bet (378) returned to winghymliu
+winghymliu collected 378 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 400 | Rake 22 
+Board [Jd 7c Ac]
+Seat 1: hellokwanny (big blind) folded on the Flop
+Seat 4: pokeher878787 folded on the Flop
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 8: winghymliu (button) collected (378)
+Seat 9: no1beyondfan888 (small blind) folded on the Flop
+
+
+
+PokerStars Home Game Hand #211262360345: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:19:02 WET [2020/04/03 16:19:02 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (9850 in chips) 
+Seat 4: pokeher878787 (10257 in chips) 
+Seat 5: scra88le56 (21075 in chips) 
+Seat 8: winghymliu (14788 in chips) 
+Seat 9: no1beyondfan888 (39434 in chips) 
+hellokwanny: posts small blind 50
+pokeher878787: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Ks 3s]
+scra88le56: folds 
+winghymliu: folds 
+no1beyondfan888: calls 100
+hellokwanny: folds 
+pokeher878787: checks 
+*** FLOP *** [Qc Ah 5c]
+pokeher878787: checks 
+no1beyondfan888: checks 
+*** TURN *** [Qc Ah 5c] [Kc]
+pokeher878787: bets 100
+no1beyondfan888: calls 100
+*** RIVER *** [Qc Ah 5c Kc] [Kd]
+pokeher878787: bets 100
+no1beyondfan888: raises 625 to 725
+pokeher878787: folds 
+Uncalled bet (625) returned to no1beyondfan888
+no1beyondfan888 collected 614 from pot
+no1beyondfan888: doesn't show hand 
+*** SUMMARY ***
+Total pot 650 | Rake 36 
+Board [Qc Ah 5c Kc Kd]
+Seat 1: hellokwanny (small blind) folded before Flop
+Seat 4: pokeher878787 (big blind) folded on the River
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 8: winghymliu folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 (button) collected (614)
+
+
+
+PokerStars Home Game Hand #211262423404: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:19:45 WET [2020/04/03 16:19:45 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (9800 in chips) 
+Seat 4: pokeher878787 (9957 in chips) 
+Seat 5: scra88le56 (21075 in chips) 
+Seat 8: winghymliu (14788 in chips) 
+Seat 9: no1beyondfan888 (39748 in chips) 
+pokeher878787: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [7c 6h]
+winghymliu: folds 
+no1beyondfan888: calls 100
+hellokwanny: raises 300 to 400
+pokeher878787: calls 350
+scra88le56: calls 300
+no1beyondfan888: calls 300
+*** FLOP *** [Qh 3c 8d]
+420justblazeit joins the table at seat #6 
+pokeher878787: bets 100
+scra88le56: calls 100
+no1beyondfan888: calls 100
+hellokwanny: calls 100
+*** TURN *** [Qh 3c 8d] [Qd]
+pokeher878787: bets 100
+scra88le56: calls 100
+no1beyondfan888: calls 100
+hellokwanny: calls 100
+*** RIVER *** [Qh 3c 8d Qd] [3d]
+pokeher878787: bets 100
+scra88le56: calls 100
+no1beyondfan888: raises 2568 to 2668
+hellokwanny: folds 
+pokeher878787: folds 
+scra88le56: folds 
+Uncalled bet (2568) returned to no1beyondfan888
+no1beyondfan888 collected 2551 from pot
+no1beyondfan888: doesn't show hand 
+*** SUMMARY ***
+Total pot 2700 | Rake 149 
+Board [Qh 3c 8d Qd 3d]
+Seat 1: hellokwanny (button) folded on the River
+Seat 4: pokeher878787 (small blind) folded on the River
+Seat 5: scra88le56 (big blind) folded on the River
+Seat 8: winghymliu folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 collected (2551)
+
+
+
+PokerStars Home Game Hand #211262525625: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:20:53 WET [2020/04/03 16:20:53 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #4 is the button
+Seat 1: hellokwanny (9200 in chips) 
+Seat 4: pokeher878787 (9257 in chips) 
+Seat 5: scra88le56 (20375 in chips) 
+Seat 6: 420justblazeit (10000 in chips) 
+Seat 8: winghymliu (14788 in chips) 
+Seat 9: no1beyondfan888 (41599 in chips) 
+scra88le56: posts small blind 50
+420justblazeit: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Ah Jd]
+winghymliu: folds 
+no1beyondfan888: folds 
+hellokwanny: raises 300 to 400
+pokeher878787: calls 400
+scra88le56: calls 350
+420justblazeit: folds 
+*** FLOP *** [2h Th Jh]
+scra88le56: checks 
+hellokwanny: bets 614
+pokeher878787: raises 614 to 1228
+scra88le56: folds 
+hellokwanny: calls 614
+*** TURN *** [2h Th Jh] [Tc]
+hellokwanny: bets 1774
+pokeher878787: calls 1774
+*** RIVER *** [2h Th Jh Tc] [Ad]
+hellokwanny: bets 5798 and is all-in
+pokeher878787: folds 
+Uncalled bet (5798) returned to hellokwanny
+hellokwanny collected 6902 from pot
+hellokwanny: doesn't show hand 
+*** SUMMARY ***
+Total pot 7304 | Rake 402 
+Board [2h Th Jh Tc Ad]
+Seat 1: hellokwanny collected (6902)
+Seat 4: pokeher878787 (button) folded on the River
+Seat 5: scra88le56 (small blind) folded on the Flop
+Seat 6: 420justblazeit (big blind) folded before Flop
+Seat 8: winghymliu folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211262611631: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:21:50 WET [2020/04/03 16:21:50 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (12700 in chips) 
+Seat 4: pokeher878787 (5855 in chips) 
+Seat 5: scra88le56 (19975 in chips) 
+Seat 6: 420justblazeit (9900 in chips) 
+Seat 8: winghymliu (14788 in chips) 
+Seat 9: no1beyondfan888 (41599 in chips) 
+420justblazeit: posts small blind 50
+winghymliu: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [5s 9d]
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: calls 100
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: checks 
+*** FLOP *** [8h Kd 9s]
+winghymliu: checks 
+pokeher878787: bets 100
+winghymliu: calls 100
+*** TURN *** [8h Kd 9s] [7d]
+winghymliu: checks 
+pokeher878787: bets 212
+winghymliu: folds 
+Uncalled bet (212) returned to pokeher878787
+pokeher878787 collected 425 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 450 | Rake 25 
+Board [8h Kd 9s 7d]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 collected (425)
+Seat 5: scra88le56 (button) folded before Flop (didn't bet)
+Seat 6: 420justblazeit (small blind) folded before Flop
+Seat 8: winghymliu (big blind) folded on the Turn
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211262698072: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:22:48 WET [2020/04/03 16:22:48 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (12700 in chips) 
+Seat 4: pokeher878787 (6080 in chips) 
+Seat 5: scra88le56 (19975 in chips) 
+Seat 6: 420justblazeit (9850 in chips) 
+Seat 8: winghymliu (14588 in chips) 
+Seat 9: no1beyondfan888 (41599 in chips) 
+winghymliu: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Qh 3h]
+hellokwanny: folds 
+pokeher878787: calls 100
+scra88le56: calls 100
+420justblazeit: raises 300 to 400
+winghymliu: calls 350
+no1beyondfan888: folds 
+pokeher878787: folds 
+scra88le56: calls 300
+*** FLOP *** [3s 2c Qc]
+winghymliu: checks 
+scra88le56: checks 
+420justblazeit: bets 661
+winghymliu: folds 
+scra88le56: folds 
+Uncalled bet (661) returned to 420justblazeit
+420justblazeit collected 1323 from pot
+420justblazeit: doesn't show hand 
+*** SUMMARY ***
+Total pot 1400 | Rake 77 
+Board [3s 2c Qc]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 folded before Flop
+Seat 5: scra88le56 folded on the Flop
+Seat 6: 420justblazeit (button) collected (1323)
+Seat 8: winghymliu (small blind) folded on the Flop
+Seat 9: no1beyondfan888 (big blind) folded before Flop
+
+
+
+PokerStars Home Game Hand #211262772233: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:23:40 WET [2020/04/03 16:23:40 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (12700 in chips) 
+Seat 4: pokeher878787 (5980 in chips) 
+Seat 5: scra88le56 (19575 in chips) 
+Seat 6: 420justblazeit (10773 in chips) 
+Seat 8: winghymliu (14188 in chips) 
+Seat 9: no1beyondfan888 (41499 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [6h 9d]
+pokeher878787: raises 200 to 300
+scra88le56: raises 700 to 1000
+420justblazeit: folds 
+winghymliu: folds 
+no1beyondfan888: calls 950
+hellokwanny: folds 
+pokeher878787: calls 700
+*** FLOP *** [6c 5h 8d]
+no1beyondfan888: checks 
+pokeher878787: bets 100
+scra88le56: raises 1800 to 1900
+no1beyondfan888: folds 
+pokeher878787: folds 
+Uncalled bet (1800) returned to scra88le56
+scra88le56 collected 3118 from pot
+scra88le56: doesn't show hand 
+*** SUMMARY ***
+Total pot 3300 | Rake 182 
+Board [6c 5h 8d]
+Seat 1: hellokwanny (big blind) folded before Flop
+Seat 4: pokeher878787 folded on the Flop
+Seat 5: scra88le56 collected (3118)
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu (button) folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 (small blind) folded on the Flop
+
+
+
+PokerStars Home Game Hand #211262870509: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:24:41 WET [2020/04/03 16:24:41 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (12600 in chips) 
+Seat 4: pokeher878787 (4880 in chips) 
+Seat 5: scra88le56 (21593 in chips) 
+Seat 6: 420justblazeit (10773 in chips) 
+Seat 8: winghymliu (14188 in chips) 
+Seat 9: no1beyondfan888 (40499 in chips) 
+hellokwanny: posts small blind 50
+pokeher878787: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Kc Ts]
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: calls 100
+no1beyondfan888: calls 100
+hellokwanny: calls 50
+pokeher878787: checks 
+*** FLOP *** [7h Ks 6d]
+hellokwanny: checks 
+pokeher878787: checks 
+winghymliu: checks 
+no1beyondfan888: checks 
+*** TURN *** [7h Ks 6d] [Qc]
+hellokwanny: bets 100
+pokeher878787: calls 100
+winghymliu: calls 100
+no1beyondfan888: calls 100
+*** RIVER *** [7h Ks 6d Qc] [9c]
+hellokwanny: bets 504
+pokeher878787: folds 
+winghymliu: folds 
+no1beyondfan888: calls 504
+*** SHOW DOWN ***
+hellokwanny: shows [Kc Ts] (a pair of Kings)
+no1beyondfan888: mucks hand 
+hellokwanny collected 1709 from pot
+*** SUMMARY ***
+Total pot 1808 | Rake 99 
+Board [7h Ks 6d Qc 9c]
+Seat 1: hellokwanny (small blind) showed [Kc Ts] and won (1709) with a pair of Kings
+Seat 4: pokeher878787 (big blind) folded on the River
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu folded on the River
+Seat 9: no1beyondfan888 (button) mucked [Ad 5s]
+
+
+
+PokerStars Home Game Hand #211262990084: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:26:02 WET [2020/04/03 16:26:02 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (13605 in chips) 
+Seat 4: pokeher878787 (4680 in chips) 
+Seat 5: scra88le56 (21593 in chips) 
+Seat 6: 420justblazeit (10773 in chips) 
+Seat 8: winghymliu (13988 in chips) 
+Seat 9: no1beyondfan888 (39795 in chips) 
+pokeher878787: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Ts 8c]
+420justblazeit: folds 
+winghymliu: folds 
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: calls 50
+scra88le56: checks 
+*** FLOP *** [3c 6c 9d]
+pokeher878787: checks 
+scra88le56: checks 
+*** TURN *** [3c 6c 9d] [Kd]
+pokeher878787: bets 100
+scra88le56: folds 
+Uncalled bet (100) returned to pokeher878787
+pokeher878787 collected 189 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 200 | Rake 11 
+Board [3c 6c 9d Kd]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 4: pokeher878787 (small blind) collected (189)
+Seat 5: scra88le56 (big blind) folded on the Turn
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211263089842: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:27:10 WET [2020/04/03 16:27:10 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #4 is the button
+Seat 1: hellokwanny (13605 in chips) 
+Seat 4: pokeher878787 (4769 in chips) 
+Seat 5: scra88le56 (21493 in chips) 
+Seat 6: 420justblazeit (10773 in chips) 
+Seat 8: winghymliu (13988 in chips) 
+Seat 9: no1beyondfan888 (39795 in chips) 
+scra88le56: posts small blind 50
+420justblazeit: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [9c Ks]
+winghymliu: folds 
+no1beyondfan888: calls 100
+hellokwanny: folds 
+pokeher878787: raises 200 to 300
+scra88le56: folds 
+420justblazeit: raises 300 to 600
+no1beyondfan888: calls 500
+pokeher878787: calls 300
+*** FLOP *** [Qc 3d Qh]
+420justblazeit: bets 874
+no1beyondfan888: folds 
+pokeher878787: folds 
+Uncalled bet (874) returned to 420justblazeit
+420justblazeit collected 1748 from pot
+420justblazeit: doesn't show hand 
+*** SUMMARY ***
+Total pot 1850 | Rake 102 
+Board [Qc 3d Qh]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 (button) folded on the Flop
+Seat 5: scra88le56 (small blind) folded before Flop
+Seat 6: 420justblazeit (big blind) collected (1748)
+Seat 8: winghymliu folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 folded on the Flop
+
+
+
+PokerStars Home Game Hand #211263162239: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:28:01 WET [2020/04/03 16:28:01 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (13605 in chips) 
+Seat 4: pokeher878787 (4169 in chips) 
+Seat 5: scra88le56 (21443 in chips) 
+Seat 6: 420justblazeit (11921 in chips) 
+Seat 8: winghymliu (13988 in chips) 
+Seat 9: no1beyondfan888 (39195 in chips) 
+420justblazeit: posts small blind 50
+winghymliu: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [3h Qh]
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: raises 200 to 300
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: calls 200
+*** FLOP *** [4s 2c Qc]
+winghymliu: bets 614
+pokeher878787: folds 
+Uncalled bet (614) returned to winghymliu
+winghymliu collected 614 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 650 | Rake 36 
+Board [4s 2c Qc]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 folded on the Flop
+Seat 5: scra88le56 (button) folded before Flop (didn't bet)
+Seat 6: 420justblazeit (small blind) folded before Flop
+Seat 8: winghymliu (big blind) collected (614)
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211263229981: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:28:48 WET [2020/04/03 16:28:48 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (13605 in chips) 
+Seat 4: pokeher878787 (3869 in chips) 
+Seat 5: scra88le56 (21443 in chips) 
+Seat 6: 420justblazeit (11871 in chips) 
+Seat 8: winghymliu (14302 in chips) 
+Seat 9: no1beyondfan888 (39195 in chips) 
+winghymliu: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [3c Jc]
+hellokwanny: folds 
+pokeher878787: calls 100
+scra88le56: calls 100
+420justblazeit: folds 
+winghymliu: calls 50
+no1beyondfan888: checks 
+*** FLOP *** [8d 3h 5s]
+winghymliu: checks 
+no1beyondfan888: bets 100
+pokeher878787: folds 
+scra88le56: calls 100
+winghymliu: folds 
+*** TURN *** [8d 3h 5s] [Td]
+no1beyondfan888: checks 
+scra88le56: checks 
+*** RIVER *** [8d 3h 5s Td] [Kd]
+no1beyondfan888: bets 567
+scra88le56: folds 
+Uncalled bet (567) returned to no1beyondfan888
+no1beyondfan888 collected 567 from pot
+no1beyondfan888: doesn't show hand 
+*** SUMMARY ***
+Total pot 600 | Rake 33 
+Board [8d 3h 5s Td Kd]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 folded on the Flop
+Seat 5: scra88le56 folded on the River
+Seat 6: 420justblazeit (button) folded before Flop (didn't bet)
+Seat 8: winghymliu (small blind) folded on the Flop
+Seat 9: no1beyondfan888 (big blind) collected (567)
+
+
+
+PokerStars Home Game Hand #211263340275: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:30:04 WET [2020/04/03 16:30:04 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (13605 in chips) 
+Seat 4: pokeher878787 (3769 in chips) 
+Seat 5: scra88le56 (21243 in chips) 
+Seat 6: 420justblazeit (11871 in chips) 
+Seat 8: winghymliu (14202 in chips) 
+Seat 9: no1beyondfan888 (39562 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [5h Th]
+pokeher878787: calls 100
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: calls 100
+no1beyondfan888: raises 400 to 500
+hellokwanny: folds 
+pokeher878787: folds 
+winghymliu: calls 400
+*** FLOP *** [2c 8s 9s]
+no1beyondfan888: checks 
+winghymliu: checks 
+*** TURN *** [2c 8s 9s] [Ad]
+no1beyondfan888: checks 
+winghymliu: bets 1134
+no1beyondfan888: calls 1134
+*** RIVER *** [2c 8s 9s Ad] [3c]
+no1beyondfan888: checks 
+winghymliu: bets 3277
+no1beyondfan888: calls 3277
+*** SHOW DOWN ***
+winghymliu: shows [7d Ah] (a pair of Aces)
+no1beyondfan888: mucks hand 
+winghymliu collected 9471 from pot
+*** SUMMARY ***
+Total pot 10022 | Rake 551 
+Board [2c 8s 9s Ad 3c]
+Seat 1: hellokwanny (big blind) folded before Flop
+Seat 4: pokeher878787 folded before Flop
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu (button) showed [7d Ah] and won (9471) with a pair of Aces
+Seat 9: no1beyondfan888 (small blind) mucked [Kd Kh]
+
+
+
+PokerStars Home Game Hand #211263480332: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:31:40 WET [2020/04/03 16:31:40 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (13505 in chips) 
+Seat 4: pokeher878787 (3669 in chips) 
+Seat 5: scra88le56 (21243 in chips) 
+Seat 6: 420justblazeit (11871 in chips) 
+Seat 8: winghymliu (18762 in chips) 
+Seat 9: no1beyondfan888 (34651 in chips) 
+hellokwanny: posts small blind 50
+pokeher878787: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [8d Jh]
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: folds 
+no1beyondfan888: folds 
+hellokwanny: calls 50
+pokeher878787: checks 
+*** FLOP *** [Qs Td 3c]
+hellokwanny: bets 100
+pokeher878787: calls 100
+*** TURN *** [Qs Td 3c] [Qc]
+hellokwanny: bets 300
+pokeher878787: calls 300
+*** RIVER *** [Qs Td 3c Qc] [9s]
+hellokwanny: bets 945
+pokeher878787: folds 
+Uncalled bet (945) returned to hellokwanny
+hellokwanny collected 945 from pot
+hellokwanny: doesn't show hand 
+*** SUMMARY ***
+Total pot 1000 | Rake 55 
+Board [Qs Td 3c Qc 9s]
+Seat 1: hellokwanny (small blind) collected (945)
+Seat 4: pokeher878787 (big blind) folded on the River
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 (button) folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211263552775: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:32:30 WET [2020/04/03 16:32:30 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (13950 in chips) 
+Seat 4: pokeher878787 (3169 in chips) 
+Seat 5: scra88le56 (21243 in chips) 
+Seat 6: 420justblazeit (11871 in chips) 
+Seat 8: winghymliu (18762 in chips) 
+Seat 9: no1beyondfan888 (34651 in chips) 
+pokeher878787: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [6c 7s]
+420justblazeit: folds 
+winghymliu: raises 100 to 200
+no1beyondfan888: calls 200
+hellokwanny: folds 
+pokeher878787: calls 150
+scra88le56: calls 100
+*** FLOP *** [4s 9d Ac]
+pokeher878787: checks 
+scra88le56: checks 
+winghymliu: checks 
+no1beyondfan888: checks 
+*** TURN *** [4s 9d Ac] [2c]
+pokeher878787: checks 
+scra88le56: checks 
+winghymliu: checks 
+no1beyondfan888: checks 
+*** RIVER *** [4s 9d Ac 2c] [Ah]
+pokeher878787: checks 
+scra88le56: bets 500
+winghymliu: calls 500
+no1beyondfan888: calls 500
+pokeher878787: folds 
+*** SHOW DOWN ***
+scra88le56: shows [3d Qs] (a pair of Aces)
+winghymliu: shows [Kd Qc] (a pair of Aces - King kicker)
+no1beyondfan888: mucks hand 
+winghymliu collected 2173 from pot
+*** SUMMARY ***
+Total pot 2300 | Rake 127 
+Board [4s 9d Ac 2c Ah]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 4: pokeher878787 (small blind) folded on the River
+Seat 5: scra88le56 (big blind) showed [3d Qs] and lost with a pair of Aces
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu showed [Kd Qc] and won (2173) with a pair of Aces
+Seat 9: no1beyondfan888 mucked [Ks 7h]
+
+
+
+PokerStars Home Game Hand #211263675633: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:33:50 WET [2020/04/03 16:33:50 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #4 is the button
+Seat 1: hellokwanny (13950 in chips) 
+Seat 4: pokeher878787 (2969 in chips) 
+Seat 5: scra88le56 (20543 in chips) 
+Seat 6: 420justblazeit (11871 in chips) 
+Seat 8: winghymliu (20235 in chips) 
+Seat 9: no1beyondfan888 (33951 in chips) 
+scra88le56: posts small blind 50
+420justblazeit: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [5d Qd]
+winghymliu: calls 100
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: calls 100
+scra88le56: raises 600 to 700
+420justblazeit: folds 
+winghymliu: calls 600
+pokeher878787: folds 
+*** FLOP *** [4d 9d 9h]
+scra88le56: checks 
+winghymliu: checks 
+*** TURN *** [4d 9d 9h] [9s]
+scra88le56: bets 700
+winghymliu: folds 
+Uncalled bet (700) returned to scra88le56
+scra88le56 collected 1512 from pot
+scra88le56: doesn't show hand 
+*** SUMMARY ***
+Total pot 1600 | Rake 88 
+Board [4d 9d 9h 9s]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 (button) folded before Flop
+Seat 5: scra88le56 (small blind) collected (1512)
+Seat 6: 420justblazeit (big blind) folded before Flop
+Seat 8: winghymliu folded on the Turn
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211263758667: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:34:48 WET [2020/04/03 16:34:48 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (13950 in chips) 
+Seat 4: pokeher878787 (2869 in chips) 
+Seat 5: scra88le56 (21355 in chips) 
+Seat 6: 420justblazeit (11771 in chips) 
+Seat 8: winghymliu (19535 in chips) 
+Seat 9: no1beyondfan888 (33951 in chips) 
+420justblazeit: posts small blind 50
+winghymliu: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Qd 9s]
+no1beyondfan888: raises 100 to 200
+hellokwanny: calls 200
+pokeher878787: calls 200
+scra88le56: raises 400 to 600
+420justblazeit: folds 
+winghymliu: folds 
+no1beyondfan888: calls 400
+hellokwanny: folds 
+pokeher878787: calls 400
+*** FLOP *** [4h 2d 9d]
+no1beyondfan888: checks 
+pokeher878787: bets 100
+scra88le56: calls 100
+no1beyondfan888: raises 1166 to 1266
+pokeher878787: folds 
+scra88le56: calls 1166
+*** TURN *** [4h 2d 9d] [Ts]
+no1beyondfan888: checks 
+scra88le56: checks 
+*** RIVER *** [4h 2d 9d Ts] [Jd]
+no1beyondfan888: checks 
+scra88le56: checks 
+*** SHOW DOWN ***
+no1beyondfan888: shows [Js Ad] (a pair of Jacks)
+scra88le56: mucks hand 
+no1beyondfan888 collected 4519 from pot
+*** SUMMARY ***
+Total pot 4782 | Rake 263 
+Board [4h 2d 9d Ts Jd]
+Seat 1: hellokwanny folded before Flop
+Seat 4: pokeher878787 folded on the Flop
+Seat 5: scra88le56 (button) mucked [Kd Ac]
+Seat 6: 420justblazeit (small blind) folded before Flop
+Seat 8: winghymliu (big blind) folded before Flop
+Seat 9: no1beyondfan888 showed [Js Ad] and won (4519) with a pair of Jacks
+
+
+
+PokerStars Home Game Hand #211263867581: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:36:03 WET [2020/04/03 16:36:03 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (13750 in chips) 
+Seat 4: pokeher878787 (2169 in chips) 
+Seat 5: scra88le56 (19489 in chips) 
+Seat 6: 420justblazeit (11721 in chips) 
+Seat 8: winghymliu (19435 in chips) 
+Seat 9: no1beyondfan888 (36604 in chips) 
+winghymliu: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Th 9c]
+hellokwanny: folds 
+pokeher878787: folds 
+scra88le56: raises 900 to 1000
+420justblazeit: folds 
+winghymliu: folds 
+no1beyondfan888: folds 
+Uncalled bet (900) returned to scra88le56
+scra88le56 collected 250 from pot
+scra88le56: doesn't show hand 
+*** SUMMARY ***
+Total pot 250 | Rake 0 
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 folded before Flop (didn't bet)
+Seat 5: scra88le56 collected (250)
+Seat 6: 420justblazeit (button) folded before Flop (didn't bet)
+Seat 8: winghymliu (small blind) folded before Flop
+Seat 9: no1beyondfan888 (big blind) folded before Flop
+
+
+
+PokerStars Home Game Hand #211263906860: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:36:31 WET [2020/04/03 16:36:31 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (13750 in chips) 
+Seat 4: pokeher878787 (2169 in chips) 
+Seat 5: scra88le56 (19639 in chips) 
+Seat 6: 420justblazeit (11721 in chips) 
+Seat 8: winghymliu (19385 in chips) 
+Seat 9: no1beyondfan888 (36504 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [6c 8c]
+pokeher878787: folds 
+scra88le56: raises 500 to 600
+420justblazeit: folds 
+winghymliu: calls 600
+no1beyondfan888: folds 
+hellokwanny: folds 
+*** FLOP *** [Jd Ac 3h]
+scra88le56: checks 
+winghymliu: bets 638
+scra88le56: calls 638
+*** TURN *** [Jd Ac 3h] [Jc]
+scra88le56: checks 
+winghymliu: bets 2482
+scra88le56: folds 
+Uncalled bet (2482) returned to winghymliu
+winghymliu collected 2482 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 2626 | Rake 144 
+Board [Jd Ac 3h Jc]
+Seat 1: hellokwanny (big blind) folded before Flop
+Seat 4: pokeher878787 folded before Flop (didn't bet)
+Seat 5: scra88le56 folded on the Turn
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu (button) collected (2482)
+Seat 9: no1beyondfan888 (small blind) folded before Flop
+
+
+
+PokerStars Home Game Hand #211263986973: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:37:27 WET [2020/04/03 16:37:27 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (13650 in chips) 
+Seat 4: pokeher878787 (2169 in chips) 
+Seat 5: scra88le56 (18401 in chips) 
+Seat 6: 420justblazeit (11721 in chips) 
+Seat 8: winghymliu (20629 in chips) 
+Seat 9: no1beyondfan888 (36454 in chips) 
+hellokwanny: posts small blind 50
+pokeher878787: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [9h Kh]
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: raises 250 to 350
+no1beyondfan888: calls 350
+hellokwanny: calls 300
+pokeher878787: folds 
+*** FLOP *** [7s 6h 8h]
+hellokwanny: bets 543
+winghymliu: raises 2173 to 2716
+no1beyondfan888: folds 
+hellokwanny: calls 2173
+*** TURN *** [7s 6h 8h] [Ks]
+hellokwanny: bets 3110
+winghymliu: calls 3110
+*** RIVER *** [7s 6h 8h Ks] [8d]
+hellokwanny: bets 6049
+winghymliu: calls 6049
+*** SHOW DOWN ***
+hellokwanny: shows [9h Kh] (two pair, Kings and Eights)
+winghymliu: mucks hand 
+hellokwanny collected 23530 from pot
+*** SUMMARY ***
+Total pot 24900 | Rake 1370 
+Board [7s 6h 8h Ks 8d]
+Seat 1: hellokwanny (small blind) showed [9h Kh] and won (23530) with two pair, Kings and Eights
+Seat 4: pokeher878787 (big blind) folded before Flop
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu mucked [9d 9s]
+Seat 9: no1beyondfan888 (button) folded on the Flop
+
+
+
+PokerStars Home Game Hand #211264117155: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:38:54 WET [2020/04/03 16:38:54 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (24955 in chips) 
+Seat 4: pokeher878787 (2069 in chips) 
+Seat 5: scra88le56 (18401 in chips) 
+Seat 6: 420justblazeit (11721 in chips) 
+Seat 8: winghymliu (8404 in chips) 
+Seat 9: no1beyondfan888 (36104 in chips) 
+pokeher878787: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [3c 8d]
+420justblazeit: folds 
+winghymliu: folds 
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: calls 50
+scra88le56: checks 
+*** FLOP *** [8h Jc Kh]
+pokeher878787: checks 
+scra88le56: bets 16500
+pokeher878787: folds 
+Uncalled bet (16500) returned to scra88le56
+scra88le56 collected 189 from pot
+scra88le56: doesn't show hand 
+*** SUMMARY ***
+Total pot 200 | Rake 11 
+Board [8h Jc Kh]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 4: pokeher878787 (small blind) folded on the Flop
+Seat 5: scra88le56 (big blind) collected (189)
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211264176421: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:39:34 WET [2020/04/03 16:39:34 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #4 is the button
+Seat 1: hellokwanny (24955 in chips) 
+Seat 4: pokeher878787 (1969 in chips) 
+Seat 5: scra88le56 (18490 in chips) 
+Seat 6: 420justblazeit (11721 in chips) 
+Seat 8: winghymliu (8404 in chips) 
+Seat 9: no1beyondfan888 (36104 in chips) 
+scra88le56: posts small blind 50
+420justblazeit: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [3s 6h]
+winghymliu: folds 
+no1beyondfan888: calls 100
+hellokwanny: folds 
+pokeher878787: folds 
+scra88le56: calls 50
+420justblazeit: checks 
+*** FLOP *** [2d Js 5c]
+scra88le56: checks 
+420justblazeit: bets 283
+no1beyondfan888: calls 283
+scra88le56: folds 
+*** TURN *** [2d Js 5c] [As]
+420justblazeit: bets 409
+no1beyondfan888: calls 409
+*** RIVER *** [2d Js 5c As] [5s]
+420justblazeit: checks 
+no1beyondfan888: checks 
+*** SHOW DOWN ***
+420justblazeit: shows [Jd 7s] (two pair, Jacks and Fives)
+no1beyondfan888: shows [Kd Jh] (two pair, Jacks and Fives)
+420justblazeit collected 796 from pot
+no1beyondfan888 collected 795 from pot
+*** SUMMARY ***
+Total pot 1684 | Rake 93 
+Board [2d Js 5c As 5s]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 (button) folded before Flop (didn't bet)
+Seat 5: scra88le56 (small blind) folded on the Flop
+Seat 6: 420justblazeit (big blind) showed [Jd 7s] and won (796) with two pair, Jacks and Fives
+Seat 8: winghymliu folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 showed [Kd Jh] and won (795) with two pair, Jacks and Fives
+
+
+
+PokerStars Home Game Hand #211264260967: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:40:34 WET [2020/04/03 16:40:34 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (24955 in chips) 
+Seat 4: pokeher878787 (1969 in chips) 
+Seat 5: scra88le56 (18390 in chips) 
+Seat 6: 420justblazeit (11725 in chips) 
+Seat 8: winghymliu (8404 in chips) 
+Seat 9: no1beyondfan888 (36107 in chips) 
+420justblazeit: posts small blind 50
+winghymliu: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Td 2h]
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: folds 
+scra88le56: calls 100
+420justblazeit: folds 
+winghymliu: checks 
+*** FLOP *** [5d 8d As]
+winghymliu: checks 
+scra88le56: bets 200
+winghymliu: folds 
+Uncalled bet (200) returned to scra88le56
+scra88le56 collected 236 from pot
+scra88le56: doesn't show hand 
+*** SUMMARY ***
+Total pot 250 | Rake 14 
+Board [5d 8d As]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 folded before Flop (didn't bet)
+Seat 5: scra88le56 (button) collected (236)
+Seat 6: 420justblazeit (small blind) folded before Flop
+Seat 8: winghymliu (big blind) folded on the Flop
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211264341536: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:41:29 WET [2020/04/03 16:41:29 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (24955 in chips) 
+Seat 4: pokeher878787 (1969 in chips) 
+Seat 5: scra88le56 (18526 in chips) 
+Seat 6: 420justblazeit (11675 in chips) 
+Seat 8: winghymliu (8304 in chips) 
+Seat 9: no1beyondfan888 (36107 in chips) 
+winghymliu: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [8c Qh]
+hellokwanny: folds 
+pokeher878787: folds 
+scra88le56: folds 
+420justblazeit: raises 300 to 400
+winghymliu: folds 
+no1beyondfan888: folds 
+Uncalled bet (300) returned to 420justblazeit
+420justblazeit collected 250 from pot
+420justblazeit: doesn't show hand 
+*** SUMMARY ***
+Total pot 250 | Rake 0 
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 folded before Flop (didn't bet)
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit (button) collected (250)
+Seat 8: winghymliu (small blind) folded before Flop
+Seat 9: no1beyondfan888 (big blind) folded before Flop
+
+
+
+PokerStars Home Game Hand #211264383649: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:41:58 WET [2020/04/03 16:41:58 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (24955 in chips) 
+Seat 4: pokeher878787 (1969 in chips) 
+Seat 5: scra88le56 (18526 in chips) 
+Seat 6: 420justblazeit (11825 in chips) 
+Seat 8: winghymliu (8254 in chips) 
+Seat 9: no1beyondfan888 (36007 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [7d Qh]
+pokeher878787: folds 
+scra88le56: raises 300 to 400
+420justblazeit: folds 
+winghymliu: calls 400
+no1beyondfan888: folds 
+hellokwanny: folds 
+*** FLOP *** [7h 9c 6d]
+scra88le56: bets 300
+winghymliu: raises 1498 to 1798
+scra88le56: folds 
+Uncalled bet (1498) returned to winghymliu
+winghymliu collected 1465 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 1550 | Rake 85 
+Board [7h 9c 6d]
+Seat 1: hellokwanny (big blind) folded before Flop
+Seat 4: pokeher878787 folded before Flop (didn't bet)
+Seat 5: scra88le56 folded on the Flop
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu (button) collected (1465)
+Seat 9: no1beyondfan888 (small blind) folded before Flop
+
+
+
+PokerStars Home Game Hand #211264442814: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:42:39 WET [2020/04/03 16:42:39 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (24855 in chips) 
+Seat 4: pokeher878787 (1969 in chips) 
+Seat 5: scra88le56 (17826 in chips) 
+Seat 6: 420justblazeit (11825 in chips) 
+Seat 8: winghymliu (9019 in chips) 
+Seat 9: no1beyondfan888 (35957 in chips) 
+hellokwanny: posts small blind 50
+pokeher878787: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Ac Qc]
+scra88le56: calls 100
+420justblazeit: folds 
+winghymliu: calls 100
+no1beyondfan888: calls 100
+hellokwanny: calls 50
+pokeher878787: checks 
+*** FLOP *** [7h Ts 8d]
+hellokwanny: checks 
+pokeher878787: checks 
+scra88le56: checks 
+winghymliu: checks 
+no1beyondfan888: bets 472
+hellokwanny: folds 
+pokeher878787: raises 1397 to 1869 and is all-in
+scra88le56: folds 
+winghymliu: calls 1869
+no1beyondfan888: calls 1397
+*** TURN *** [7h Ts 8d] [8s]
+winghymliu: checks 
+no1beyondfan888: bets 7400
+winghymliu: calls 7050 and is all-in
+Uncalled bet (350) returned to no1beyondfan888
+*** RIVER *** [7h Ts 8d 8s] [9d]
+*** SHOW DOWN ***
+winghymliu: shows [Ah 9s] (two pair, Nines and Eights)
+no1beyondfan888: shows [6s 5s] (a straight, Six to Ten)
+no1beyondfan888 collected 13325 from side pot
+pokeher878787: shows [3d 8h] (three of a kind, Eights)
+no1beyondfan888 collected 5771 from main pot
+*** SUMMARY ***
+Total pot 20207 Main pot 5771. Side pot 13325. | Rake 1111 
+Board [7h Ts 8d 8s 9d]
+Seat 1: hellokwanny (small blind) folded on the Flop
+Seat 4: pokeher878787 (big blind) showed [3d 8h] and lost with three of a kind, Eights
+Seat 5: scra88le56 folded on the Flop
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu showed [Ah 9s] and lost with two pair, Nines and Eights
+Seat 9: no1beyondfan888 (button) showed [6s 5s] and won (19096) with a straight, Six to Ten
+
+
+
+PokerStars Home Game Hand #211264572016: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:44:08 WET [2020/04/03 16:44:08 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (24755 in chips) 
+Seat 5: scra88le56 (17726 in chips) 
+Seat 6: 420justblazeit (11825 in chips) 
+Seat 9: no1beyondfan888 (46034 in chips) 
+scra88le56: posts small blind 50
+420justblazeit: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Jc Jh]
+no1beyondfan888: calls 100
+hellokwanny: raises 200 to 300
+scra88le56: calls 250
+420justblazeit: folds 
+no1beyondfan888: calls 200
+*** FLOP *** [5h Ac Tc]
+scra88le56: bets 400
+no1beyondfan888: folds 
+hellokwanny: calls 400
+*** TURN *** [5h Ac Tc] [6d]
+scra88le56: bets 300
+hellokwanny: calls 300
+*** RIVER *** [5h Ac Tc 6d] [7s]
+scra88le56: checks 
+hellokwanny: checks 
+*** SHOW DOWN ***
+scra88le56: shows [8s Ts] (a pair of Tens)
+hellokwanny: shows [Jc Jh] (a pair of Jacks)
+hellokwanny collected 2268 from pot
+*** SUMMARY ***
+Total pot 2400 | Rake 132 
+Board [5h Ac Tc 6d 7s]
+Seat 1: hellokwanny (button) showed [Jc Jh] and won (2268) with a pair of Jacks
+Seat 5: scra88le56 (small blind) showed [8s Ts] and lost with a pair of Tens
+Seat 6: 420justblazeit (big blind) folded before Flop
+Seat 9: no1beyondfan888 folded on the Flop
+
+
+
+PokerStars Home Game Hand #211264649229: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:45:01 WET [2020/04/03 16:45:01 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (26023 in chips) 
+Seat 4: pokeher878787 (10000 in chips) 
+Seat 5: scra88le56 (16726 in chips) 
+Seat 6: 420justblazeit (11725 in chips) 
+Seat 9: no1beyondfan888 (45734 in chips) 
+420justblazeit: posts small blind 50
+no1beyondfan888: posts big blind 100
+pokeher878787: posts small blind 50
+*** HOLE CARDS ***
+Dealt to hellokwanny [Th 6h]
+hellokwanny: folds 
+pokeher878787: calls 100
+scra88le56: raises 900 to 1000
+420justblazeit: folds 
+no1beyondfan888: folds 
+pokeher878787: folds 
+Uncalled bet (900) returned to scra88le56
+scra88le56 collected 400 from pot
+scra88le56: doesn't show hand 
+*** SUMMARY ***
+Total pot 400 | Rake 0 
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 folded before Flop
+Seat 5: scra88le56 (button) collected (400)
+Seat 6: 420justblazeit (small blind) folded before Flop
+Seat 9: no1beyondfan888 (big blind) folded before Flop
+
+
+
+PokerStars Home Game Hand #211264686133: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:45:26 WET [2020/04/03 16:45:26 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (26023 in chips) 
+Seat 4: pokeher878787 (9850 in chips) 
+Seat 5: scra88le56 (17026 in chips) 
+Seat 6: 420justblazeit (11675 in chips) 
+Seat 9: no1beyondfan888 (45634 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [9h 7c]
+pokeher878787: folds 
+scra88le56: folds 
+420justblazeit: folds 
+no1beyondfan888: calls 50
+hellokwanny: checks 
+*** FLOP *** [Ks 5h As]
+no1beyondfan888: bets 100
+hellokwanny: folds 
+Uncalled bet (100) returned to no1beyondfan888
+no1beyondfan888 collected 189 from pot
+no1beyondfan888: doesn't show hand 
+*** SUMMARY ***
+Total pot 200 | Rake 11 
+Board [Ks 5h As]
+Seat 1: hellokwanny (big blind) folded on the Flop
+Seat 4: pokeher878787 folded before Flop (didn't bet)
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit (button) folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 (small blind) collected (189)
+
+
+
+PokerStars Home Game Hand #211264711080: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:45:43 WET [2020/04/03 16:45:43 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (25923 in chips) 
+Seat 4: pokeher878787 (9850 in chips) 
+Seat 5: scra88le56 (17026 in chips) 
+Seat 6: 420justblazeit (11675 in chips) 
+Seat 8: winghymliu (10000 in chips) 
+Seat 9: no1beyondfan888 (45723 in chips) 
+hellokwanny: posts small blind 50
+pokeher878787: posts big blind 100
+winghymliu: posts small & big blinds 150
+*** HOLE CARDS ***
+Dealt to hellokwanny [7d Qh]
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: raises 100 to 200
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: calls 100
+*** FLOP *** [8s Th 9d]
+pokeher878787: bets 472
+winghymliu: folds 
+Uncalled bet (472) returned to pokeher878787
+pokeher878787 collected 472 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 500 | Rake 28 
+Board [8s Th 9d]
+Seat 1: hellokwanny (small blind) folded before Flop
+Seat 4: pokeher878787 (big blind) collected (472)
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu folded on the Flop
+Seat 9: no1beyondfan888 (button) folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211264758330: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:46:15 WET [2020/04/03 16:46:15 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (25873 in chips) 
+Seat 4: pokeher878787 (10122 in chips) 
+Seat 5: scra88le56 (17026 in chips) 
+Seat 6: 420justblazeit (11675 in chips) 
+Seat 8: winghymliu (9750 in chips) 
+Seat 9: no1beyondfan888 (45723 in chips) 
+pokeher878787: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [5d Ts]
+420justblazeit: calls 100
+winghymliu: folds 
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: calls 50
+scra88le56: raises 800 to 900
+420justblazeit: folds 
+pokeher878787: calls 800
+*** FLOP *** [9h 5c 3c]
+pokeher878787: bets 1795
+scra88le56: raises 14331 to 16126 and is all-in
+pokeher878787: calls 7427 and is all-in
+Uncalled bet (6904) returned to scra88le56
+*** TURN *** [9h 5c 3c] [Qd]
+*** RIVER *** [9h 5c 3c Qd] [5h]
+*** SHOW DOWN ***
+pokeher878787: shows [6c 7c] (a pair of Fives)
+scra88le56: shows [As Kh] (a pair of Fives - Ace kicker)
+scra88le56 collected 19225 from pot
+*** SUMMARY ***
+Total pot 20344 | Rake 1119 
+Board [9h 5c 3c Qd 5h]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 4: pokeher878787 (small blind) showed [6c 7c] and lost with a pair of Fives
+Seat 5: scra88le56 (big blind) showed [As Kh] and won (19225) with a pair of Fives
+Seat 6: 420justblazeit folded before Flop
+Seat 8: winghymliu folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211264838109: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:47:08 WET [2020/04/03 16:47:08 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (25873 in chips) 
+Seat 5: scra88le56 (26129 in chips) 
+Seat 6: 420justblazeit (11575 in chips) 
+Seat 8: winghymliu (9750 in chips) 
+Seat 9: no1beyondfan888 (45723 in chips) 
+420justblazeit: posts small blind 50
+winghymliu: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [4c 6c]
+no1beyondfan888: folds 
+hellokwanny: raises 200 to 300
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: folds 
+Uncalled bet (200) returned to hellokwanny
+hellokwanny collected 250 from pot
+hellokwanny: doesn't show hand 
+*** SUMMARY ***
+Total pot 250 | Rake 0 
+Seat 1: hellokwanny collected (250)
+Seat 5: scra88le56 (button) folded before Flop (didn't bet)
+Seat 6: 420justblazeit (small blind) folded before Flop
+Seat 8: winghymliu (big blind) folded before Flop
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211264891462: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:47:45 WET [2020/04/03 16:47:45 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (26023 in chips) 
+Seat 5: scra88le56 (26129 in chips) 
+Seat 6: 420justblazeit (11525 in chips) 
+Seat 8: winghymliu (9650 in chips) 
+Seat 9: no1beyondfan888 (45723 in chips) 
+winghymliu: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [6d Jh]
+hellokwanny: folds 
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: folds 
+Uncalled bet (50) returned to no1beyondfan888
+no1beyondfan888 collected 100 from pot
+no1beyondfan888: doesn't show hand 
+*** SUMMARY ***
+Total pot 100 | Rake 0 
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit (button) folded before Flop (didn't bet)
+Seat 8: winghymliu (small blind) folded before Flop
+Seat 9: no1beyondfan888 (big blind) collected (100)
+
+
+
+PokerStars Home Game Hand #211264916673: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:48:02 WET [2020/04/03 16:48:02 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (26023 in chips) 
+Seat 4: pokeher878787 (10000 in chips) 
+Seat 5: scra88le56 (26129 in chips) 
+Seat 6: 420justblazeit (11525 in chips) 
+Seat 8: winghymliu (9600 in chips) 
+Seat 9: no1beyondfan888 (45773 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Qh 6d]
+pokeher878787: calls 100
+scra88le56: calls 100
+420justblazeit: raises 200 to 300
+winghymliu: calls 300
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: calls 200
+scra88le56: calls 200
+*** FLOP *** [5c Th 5s]
+pokeher878787: checks 
+scra88le56: checks 
+420justblazeit: bets 638
+winghymliu: raises 2552 to 3190
+pokeher878787: folds 
+scra88le56: folds 
+420justblazeit: folds 
+Uncalled bet (2552) returned to winghymliu
+winghymliu collected 2482 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 2626 | Rake 144 
+Board [5c Th 5s]
+Seat 1: hellokwanny (big blind) folded before Flop
+Seat 4: pokeher878787 folded on the Flop
+Seat 5: scra88le56 folded on the Flop
+Seat 6: 420justblazeit folded on the Flop
+Seat 8: winghymliu (button) collected (2482)
+Seat 9: no1beyondfan888 (small blind) folded before Flop
+
+
+
+PokerStars Home Game Hand #211264983801: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:48:48 WET [2020/04/03 16:48:48 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (25923 in chips) 
+Seat 4: pokeher878787 (9700 in chips) 
+Seat 5: scra88le56 (25829 in chips) 
+Seat 6: 420justblazeit (10587 in chips) 
+Seat 8: winghymliu (11144 in chips) 
+pokeher878787: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [5h 4h]
+420justblazeit: folds 
+winghymliu: folds 
+hellokwanny: raises 200 to 300
+pokeher878787: folds 
+scra88le56: calls 200
+*** FLOP *** [8h 7s Ah]
+scra88le56: bets 600
+hellokwanny: calls 600
+*** TURN *** [8h 7s Ah] [Kh]
+scra88le56: bets 200
+hellokwanny: raises 700 to 900
+scra88le56: calls 700
+*** RIVER *** [8h 7s Ah Kh] [3c]
+scra88le56: checks 
+hellokwanny: bets 1724
+scra88le56: folds 
+Uncalled bet (1724) returned to hellokwanny
+hellokwanny collected 3449 from pot
+hellokwanny: doesn't show hand 
+*** SUMMARY ***
+Total pot 3650 | Rake 201 
+Board [8h 7s Ah Kh 3c]
+Seat 1: hellokwanny (button) collected (3449)
+Seat 4: pokeher878787 (small blind) folded before Flop
+Seat 5: scra88le56 (big blind) folded on the River
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211265097700: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:50:05 WET [2020/04/03 16:50:05 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #4 is the button
+Seat 1: hellokwanny (27572 in chips) 
+Seat 4: pokeher878787 (9650 in chips) 
+Seat 5: scra88le56 (24029 in chips) 
+Seat 6: 420justblazeit (10587 in chips) 
+Seat 8: winghymliu (11144 in chips) 
+Seat 9: no1beyondfan888 (45723 in chips) 
+scra88le56: posts small blind 50
+420justblazeit: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [7c Kh]
+winghymliu: folds 
+no1beyondfan888: calls 100
+hellokwanny: folds 
+pokeher878787: raises 200 to 300
+scra88le56: folds 
+420justblazeit: calls 200
+no1beyondfan888: calls 200
+*** FLOP *** [3s 8h 3d]
+420justblazeit: checks 
+no1beyondfan888: checks 
+pokeher878787: bets 449
+420justblazeit: calls 449
+no1beyondfan888: folds 
+*** TURN *** [3s 8h 3d] [Qs]
+420justblazeit: checks 
+pokeher878787: bets 1746
+420justblazeit: folds 
+Uncalled bet (1746) returned to pokeher878787
+pokeher878787 collected 1746 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 1848 | Rake 102 
+Board [3s 8h 3d Qs]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 (button) collected (1746)
+Seat 5: scra88le56 (small blind) folded before Flop
+Seat 6: 420justblazeit (big blind) folded on the Turn
+Seat 8: winghymliu folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 folded on the Flop
+
+
+
+PokerStars Home Game Hand #211265176052: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:50:59 WET [2020/04/03 16:50:59 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (27572 in chips) 
+Seat 4: pokeher878787 (10647 in chips) 
+Seat 5: scra88le56 (23979 in chips) 
+Seat 6: 420justblazeit (9838 in chips) 
+Seat 8: winghymliu (11144 in chips) 
+Seat 9: no1beyondfan888 (45423 in chips) 
+420justblazeit: posts small blind 50
+winghymliu: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [7s 8s]
+no1beyondfan888: raises 100 to 200
+hellokwanny: calls 200
+pokeher878787: calls 200
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: calls 100
+*** FLOP *** [9d 7h 4s]
+winghymliu: checks 
+no1beyondfan888: bets 401
+hellokwanny: folds 
+pokeher878787: folds 
+winghymliu: folds 
+Uncalled bet (401) returned to no1beyondfan888
+no1beyondfan888 collected 803 from pot
+no1beyondfan888: doesn't show hand 
+*** SUMMARY ***
+Total pot 850 | Rake 47 
+Board [9d 7h 4s]
+Seat 1: hellokwanny folded on the Flop
+Seat 4: pokeher878787 folded on the Flop
+Seat 5: scra88le56 (button) folded before Flop (didn't bet)
+Seat 6: 420justblazeit (small blind) folded before Flop
+Seat 8: winghymliu (big blind) folded on the Flop
+Seat 9: no1beyondfan888 collected (803)
+
+
+
+PokerStars Home Game Hand #211265236675: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:51:39 WET [2020/04/03 16:51:39 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (27372 in chips) 
+Seat 4: pokeher878787 (10447 in chips) 
+Seat 5: scra88le56 (23979 in chips) 
+Seat 6: 420justblazeit (9788 in chips) 
+Seat 8: winghymliu (10944 in chips) 
+Seat 9: no1beyondfan888 (46026 in chips) 
+winghymliu: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Td 4c]
+hellokwanny has timed out
+hellokwanny: folds 
+pokeher878787: calls 100
+scra88le56: calls 100
+420justblazeit: raises 200 to 300
+winghymliu: folds 
+no1beyondfan888: calls 200
+pokeher878787: calls 200
+scra88le56: calls 200
+*** FLOP *** [Kh 8c 6c]
+no1beyondfan888: checks 
+pokeher878787: bets 100
+scra88le56: folds 
+420justblazeit: raises 690 to 790
+no1beyondfan888: folds 
+pokeher878787: folds 
+Uncalled bet (690) returned to 420justblazeit
+420justblazeit collected 1370 from pot
+420justblazeit: doesn't show hand 
+*** SUMMARY ***
+Total pot 1450 | Rake 80 
+Board [Kh 8c 6c]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 folded on the Flop
+Seat 5: scra88le56 folded on the Flop
+Seat 6: 420justblazeit (button) collected (1370)
+Seat 8: winghymliu (small blind) folded before Flop
+Seat 9: no1beyondfan888 (big blind) folded on the Flop
+
+
+
+PokerStars Home Game Hand #211265315151: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:52:32 WET [2020/04/03 16:52:32 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (27372 in chips) 
+Seat 4: pokeher878787 (10047 in chips) 
+Seat 5: scra88le56 (23679 in chips) 
+Seat 6: 420justblazeit (10758 in chips) 
+Seat 8: winghymliu (10894 in chips) 
+Seat 9: no1beyondfan888 (45726 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Jd Ah]
+pokeher878787: raises 200 to 300
+scra88le56: raises 200 to 500
+420justblazeit: folds 
+winghymliu: folds 
+no1beyondfan888: calls 450
+hellokwanny: folds 
+pokeher878787: calls 200
+*** FLOP *** [2d 2s Ad]
+no1beyondfan888: checks 
+pokeher878787: checks 
+scra88le56: bets 600
+no1beyondfan888: calls 600
+pokeher878787: folds 
+*** TURN *** [2d 2s Ad] [7d]
+no1beyondfan888: checks 
+scra88le56: checks 
+*** RIVER *** [2d 2s Ad 7d] [6h]
+no1beyondfan888: bets 2646
+scra88le56: folds 
+Uncalled bet (2646) returned to no1beyondfan888
+no1beyondfan888 collected 2646 from pot
+no1beyondfan888: doesn't show hand 
+*** SUMMARY ***
+Total pot 2800 | Rake 154 
+Board [2d 2s Ad 7d 6h]
+Seat 1: hellokwanny (big blind) folded before Flop
+Seat 4: pokeher878787 folded on the Flop
+Seat 5: scra88le56 folded on the River
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu (button) folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 (small blind) collected (2646)
+
+
+
+PokerStars Home Game Hand #211265403006: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:53:32 WET [2020/04/03 16:53:32 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (27272 in chips) 
+Seat 4: pokeher878787 (9547 in chips) 
+Seat 5: scra88le56 (22579 in chips) 
+Seat 6: 420justblazeit (10758 in chips) 
+Seat 8: winghymliu (10894 in chips) 
+Seat 9: no1beyondfan888 (47272 in chips) 
+hellokwanny: posts small blind 50
+pokeher878787: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [7h 9d]
+scra88le56: raises 200 to 300
+420justblazeit: folds 
+winghymliu: calls 300
+no1beyondfan888: calls 300
+hellokwanny: folds 
+pokeher878787: raises 699 to 999
+scra88le56: calls 699
+winghymliu: calls 699
+no1beyondfan888: calls 699
+*** FLOP *** [Qs 2c 9h]
+pokeher878787: bets 100
+scra88le56: calls 100
+winghymliu: calls 100
+no1beyondfan888: raises 2111 to 2211
+pokeher878787: calls 2111
+scra88le56: folds 
+winghymliu: folds 
+*** TURN *** [Qs 2c 9h] [8d]
+pokeher878787: bets 234
+no1beyondfan888: raises 4329 to 4563
+pokeher878787: raises 1774 to 6337 and is all-in
+no1beyondfan888: calls 1774
+*** RIVER *** [Qs 2c 9h 8d] [As]
+*** SHOW DOWN ***
+pokeher878787: shows [9s 9c] (three of a kind, Nines)
+no1beyondfan888: shows [Qc Qd] (three of a kind, Queens)
+no1beyondfan888 collected 20168 from pot
+*** SUMMARY ***
+Total pot 21342 | Rake 1174 
+Board [Qs 2c 9h 8d As]
+Seat 1: hellokwanny (small blind) folded before Flop
+Seat 4: pokeher878787 (big blind) showed [9s 9c] and lost with three of a kind, Nines
+Seat 5: scra88le56 folded on the Flop
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu folded on the Flop
+Seat 9: no1beyondfan888 (button) showed [Qc Qd] and won (20168) with three of a kind, Queens
+
+
+
+PokerStars Home Game Hand #211265546669: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:55:17 WET [2020/04/03 16:55:17 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (27222 in chips) 
+Seat 5: scra88le56 (21480 in chips) 
+Seat 6: 420justblazeit (10758 in chips) 
+Seat 8: winghymliu (9795 in chips) 
+Seat 9: no1beyondfan888 (57893 in chips) 
+scra88le56: posts small blind 50
+420justblazeit: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [6d 4h]
+winghymliu: folds 
+no1beyondfan888: calls 100
+hellokwanny: folds 
+scra88le56: calls 50
+420justblazeit: checks 
+*** FLOP *** [7s 5c 9c]
+scra88le56: checks 
+420justblazeit: checks 
+no1beyondfan888: checks 
+*** TURN *** [7s 5c 9c] [Jh]
+scra88le56: checks 
+420justblazeit: checks 
+no1beyondfan888: bets 141
+scra88le56: folds 
+420justblazeit: calls 141
+*** RIVER *** [7s 5c 9c Jh] [7h]
+420justblazeit: checks 
+no1beyondfan888: bets 550
+420justblazeit: folds 
+Uncalled bet (550) returned to no1beyondfan888
+no1beyondfan888 collected 550 from pot
+no1beyondfan888: doesn't show hand 
+*** SUMMARY ***
+Total pot 582 | Rake 32 
+Board [7s 5c 9c Jh 7h]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 5: scra88le56 (small blind) folded on the Turn
+Seat 6: 420justblazeit (big blind) folded on the River
+Seat 8: winghymliu folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 collected (550)
+
+
+
+PokerStars Home Game Hand #211265618921: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:56:27 WET [2020/04/03 16:56:27 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (27222 in chips) 
+Seat 5: scra88le56 (21380 in chips) 
+Seat 6: 420justblazeit (10517 in chips) 
+Seat 8: winghymliu (9795 in chips) 
+Seat 9: no1beyondfan888 (58202 in chips) 
+420justblazeit: posts small blind 50
+winghymliu: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Ts Qs]
+no1beyondfan888: raises 100 to 200
+hellokwanny: raises 300 to 500
+scra88le56: calls 500
+420justblazeit: folds 
+winghymliu: calls 400
+no1beyondfan888: calls 300
+*** FLOP *** [Tc 9c 6h]
+winghymliu: bets 100
+no1beyondfan888: calls 100
+hellokwanny: raises 1100 to 1200
+scra88le56: folds 
+winghymliu: folds 
+no1beyondfan888: folds 
+Uncalled bet (1100) returned to hellokwanny
+hellokwanny collected 2221 from pot
+hellokwanny: doesn't show hand 
+*** SUMMARY ***
+Total pot 2350 | Rake 129 
+Board [Tc 9c 6h]
+Seat 1: hellokwanny collected (2221)
+Seat 5: scra88le56 (button) folded on the Flop
+Seat 6: 420justblazeit (small blind) folded before Flop
+Seat 8: winghymliu (big blind) folded on the Flop
+Seat 9: no1beyondfan888 folded on the Flop
+
+
+
+PokerStars Home Game Hand #211265671264: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:57:18 WET [2020/04/03 16:57:18 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (28843 in chips) 
+Seat 4: pokeher878787 (10000 in chips) 
+Seat 5: scra88le56 (20880 in chips) 
+Seat 6: 420justblazeit (10467 in chips) 
+Seat 8: winghymliu (9195 in chips) 
+Seat 9: no1beyondfan888 (57602 in chips) 
+winghymliu: posts small blind 50
+no1beyondfan888: posts big blind 100
+pokeher878787: posts small blind 50
+*** HOLE CARDS ***
+Dealt to hellokwanny [Qc 3s]
+hellokwanny: folds 
+pokeher878787: folds 
+scra88le56: calls 100
+420justblazeit: folds 
+winghymliu: raises 1300 to 1400
+no1beyondfan888: folds 
+scra88le56: folds 
+Uncalled bet (1300) returned to winghymliu
+winghymliu collected 350 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 350 | Rake 0 
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 folded before Flop (didn't bet)
+Seat 5: scra88le56 folded before Flop
+Seat 6: 420justblazeit (button) folded before Flop (didn't bet)
+Seat 8: winghymliu (small blind) collected (350)
+Seat 9: no1beyondfan888 (big blind) folded before Flop
+
+
+
+PokerStars Home Game Hand #211265710672: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:57:57 WET [2020/04/03 16:57:57 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (28843 in chips) 
+Seat 4: pokeher878787 (9950 in chips) 
+Seat 5: scra88le56 (20780 in chips) 
+Seat 6: 420justblazeit (10467 in chips) 
+Seat 8: winghymliu (9445 in chips) 
+Seat 9: no1beyondfan888 (57502 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [5s 9c]
+pokeher878787: raises 100 to 200
+scra88le56: raises 100 to 300
+420justblazeit: folds 
+winghymliu: calls 300
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: calls 100
+*** FLOP *** [Ts 3c 9d]
+pokeher878787: bets 100
+scra88le56: calls 100
+winghymliu: calls 100
+*** TURN *** [Ts 3c 9d] [As]
+pokeher878787: bets 100
+scra88le56: raises 500 to 600
+winghymliu: folds 
+pokeher878787: folds 
+Uncalled bet (500) returned to scra88le56
+scra88le56 collected 1465 from pot
+scra88le56: doesn't show hand 
+*** SUMMARY ***
+Total pot 1550 | Rake 85 
+Board [Ts 3c 9d As]
+Seat 1: hellokwanny (big blind) folded before Flop
+Seat 4: pokeher878787 folded on the Turn
+Seat 5: scra88le56 collected (1465)
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu (button) folded on the Turn
+Seat 9: no1beyondfan888 (small blind) folded before Flop
+
+
+
+PokerStars Home Game Hand #211265775706: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 21:59:00 WET [2020/04/03 16:59:00 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (28743 in chips) 
+Seat 4: pokeher878787 (9450 in chips) 
+Seat 5: scra88le56 (21745 in chips) 
+Seat 6: 420justblazeit (10467 in chips) 
+Seat 8: winghymliu (9045 in chips) 
+Seat 9: no1beyondfan888 (57452 in chips) 
+hellokwanny: posts small blind 50
+pokeher878787: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Ks Qd]
+scra88le56: calls 100
+420justblazeit: raises 200 to 300
+winghymliu: calls 300
+no1beyondfan888: folds 
+hellokwanny: calls 250
+pokeher878787: folds 
+scra88le56: calls 200
+*** FLOP *** [Jc 9h 3h]
+hellokwanny: checks 
+scra88le56: checks 
+420justblazeit: checks 
+winghymliu: bets 100
+hellokwanny: calls 100
+scra88le56: calls 100
+420justblazeit: calls 100
+*** TURN *** [Jc 9h 3h] [5d]
+hellokwanny: checks 
+scra88le56: checks 
+420justblazeit: checks 
+winghymliu: checks 
+*** RIVER *** [Jc 9h 3h 5d] [Qc]
+hellokwanny: checks 
+scra88le56: bets 803
+420justblazeit: folds 
+winghymliu: folds 
+hellokwanny: calls 803
+*** SHOW DOWN ***
+scra88le56: shows [Qs 7s] (a pair of Queens)
+hellokwanny: shows [Ks Qd] (a pair of Queens - King kicker)
+hellokwanny collected 3124 from pot
+*** SUMMARY ***
+Total pot 3306 | Rake 182 
+Board [Jc 9h 3h 5d Qc]
+Seat 1: hellokwanny (small blind) showed [Ks Qd] and won (3124) with a pair of Queens
+Seat 4: pokeher878787 (big blind) folded before Flop
+Seat 5: scra88le56 showed [Qs 7s] and lost with a pair of Queens
+Seat 6: 420justblazeit folded on the River
+Seat 8: winghymliu folded on the River
+Seat 9: no1beyondfan888 (button) folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211265884949: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:00:37 WET [2020/04/03 17:00:37 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (30664 in chips) 
+Seat 4: pokeher878787 (9350 in chips) 
+Seat 5: scra88le56 (20542 in chips) 
+Seat 6: 420justblazeit (10067 in chips) 
+Seat 8: winghymliu (8645 in chips) 
+Seat 9: no1beyondfan888 (57452 in chips) 
+pokeher878787: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [2h 9s]
+420justblazeit: folds 
+winghymliu has timed out
+winghymliu: folds 
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: raises 200 to 300
+scra88le56: raises 500 to 800
+pokeher878787: raises 500 to 1300
+scra88le56: calls 500
+*** FLOP *** [4s 9d As]
+pokeher878787: bets 1228
+scra88le56: raises 4172 to 5400
+pokeher878787: raises 2650 to 8050 and is all-in
+scra88le56: calls 2650
+*** TURN *** [4s 9d As] [4h]
+*** RIVER *** [4s 9d As 4h] [Qc]
+*** SHOW DOWN ***
+pokeher878787: shows [Ac 9h] (two pair, Aces and Nines)
+scra88le56: shows [Ts Ah] (two pair, Aces and Fours)
+pokeher878787 collected 17671 from pot
+*** SUMMARY ***
+Total pot 18700 | Rake 1029 
+Board [4s 9d As 4h Qc]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 4: pokeher878787 (small blind) showed [Ac 9h] and won (17671) with two pair, Aces and Nines
+Seat 5: scra88le56 (big blind) showed [Ts Ah] and lost with two pair, Aces and Fours
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211265968906: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:01:40 WET [2020/04/03 17:01:40 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #4 is the button
+Seat 1: hellokwanny (30664 in chips) 
+Seat 4: pokeher878787 (17671 in chips) 
+Seat 5: scra88le56 (11192 in chips) 
+Seat 6: 420justblazeit (10067 in chips) 
+Seat 8: winghymliu (8645 in chips) 
+Seat 9: no1beyondfan888 (57452 in chips) 
+scra88le56: posts small blind 50
+420justblazeit: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [7c 9s]
+winghymliu: folds 
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: raises 200 to 300
+scra88le56: calls 250
+420justblazeit: folds 
+*** FLOP *** [8d 9c Ah]
+scra88le56: checks 
+pokeher878787: bets 100
+scra88le56: folds 
+Uncalled bet (100) returned to pokeher878787
+pokeher878787 collected 661 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 700 | Rake 39 
+Board [8d 9c Ah]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 (button) collected (661)
+Seat 5: scra88le56 (small blind) folded on the Flop
+Seat 6: 420justblazeit (big blind) folded before Flop
+Seat 8: winghymliu folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211266014676: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:02:12 WET [2020/04/03 17:02:12 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (30664 in chips) 
+Seat 4: pokeher878787 (18032 in chips) 
+Seat 5: scra88le56 (10892 in chips) 
+Seat 6: 420justblazeit (9967 in chips) 
+Seat 8: winghymliu (8645 in chips) 
+Seat 9: no1beyondfan888 (57452 in chips) 
+420justblazeit: posts small blind 50
+winghymliu: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [5h Qd]
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: calls 100
+scra88le56: raises 500 to 600
+420justblazeit: folds 
+winghymliu: folds 
+pokeher878787: folds 
+Uncalled bet (500) returned to scra88le56
+scra88le56 collected 350 from pot
+scra88le56: doesn't show hand 
+*** SUMMARY ***
+Total pot 350 | Rake 0 
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 folded before Flop
+Seat 5: scra88le56 (button) collected (350)
+Seat 6: 420justblazeit (small blind) folded before Flop
+Seat 8: winghymliu (big blind) folded before Flop
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211266054802: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:02:39 WET [2020/04/03 17:02:39 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (30664 in chips) 
+Seat 4: pokeher878787 (17932 in chips) 
+Seat 5: scra88le56 (11142 in chips) 
+Seat 6: 420justblazeit (9917 in chips) 
+Seat 8: winghymliu (8545 in chips) 
+Seat 9: no1beyondfan888 (57452 in chips) 
+winghymliu: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [2d Ks]
+hellokwanny: folds 
+pokeher878787: raises 200 to 300
+scra88le56: calls 300
+420justblazeit: folds 
+winghymliu: calls 250
+no1beyondfan888: calls 200
+*** FLOP *** [Jc 7h 5d]
+winghymliu: checks 
+no1beyondfan888: bets 567
+pokeher878787: folds 
+scra88le56: folds 
+winghymliu: folds 
+Uncalled bet (567) returned to no1beyondfan888
+no1beyondfan888 collected 1134 from pot
+no1beyondfan888: doesn't show hand 
+*** SUMMARY ***
+Total pot 1200 | Rake 66 
+Board [Jc 7h 5d]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 folded on the Flop
+Seat 5: scra88le56 folded on the Flop
+Seat 6: 420justblazeit (button) folded before Flop (didn't bet)
+Seat 8: winghymliu (small blind) folded on the Flop
+Seat 9: no1beyondfan888 (big blind) collected (1134)
+
+
+
+PokerStars Home Game Hand #211266123850: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:03:26 WET [2020/04/03 17:03:26 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (30664 in chips) 
+Seat 4: pokeher878787 (17632 in chips) 
+Seat 5: scra88le56 (10842 in chips) 
+Seat 6: 420justblazeit (9917 in chips) 
+Seat 8: winghymliu (8245 in chips) 
+Seat 9: no1beyondfan888 (58286 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [2h 4c]
+pokeher878787: calls 100
+scra88le56: calls 100
+420justblazeit: folds 
+winghymliu: calls 100
+no1beyondfan888: calls 50
+hellokwanny: checks 
+*** FLOP *** [8s 3h Ts]
+no1beyondfan888: bets 100
+hellokwanny: folds 
+pokeher878787: calls 100
+scra88le56: calls 100
+winghymliu: calls 100
+*** TURN *** [8s 3h Ts] [5s]
+no1beyondfan888: bets 425
+pokeher878787: folds 
+scra88le56: calls 425
+winghymliu: calls 425
+*** RIVER *** [8s 3h Ts 5s] [Tc]
+no1beyondfan888: bets 2055
+scra88le56: folds 
+winghymliu: folds 
+Uncalled bet (2055) returned to no1beyondfan888
+no1beyondfan888 collected 2055 from pot
+no1beyondfan888: doesn't show hand 
+*** SUMMARY ***
+Total pot 2175 | Rake 120 
+Board [8s 3h Ts 5s Tc]
+Seat 1: hellokwanny (big blind) folded on the Flop
+Seat 4: pokeher878787 folded on the Turn
+Seat 5: scra88le56 folded on the River
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu (button) folded on the River
+Seat 9: no1beyondfan888 (small blind) collected (2055)
+
+
+
+PokerStars Home Game Hand #211266210281: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:04:17 WET [2020/04/03 17:04:17 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (30564 in chips) 
+Seat 4: pokeher878787 (17432 in chips) 
+Seat 5: scra88le56 (10217 in chips) 
+Seat 6: 420justblazeit (9917 in chips) 
+Seat 8: winghymliu (7620 in chips) 
+Seat 9: no1beyondfan888 (59716 in chips) 
+hellokwanny: posts small blind 50
+pokeher878787: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Ac Qh]
+scra88le56: folds 
+420justblazeit: raises 200 to 300
+winghymliu: folds 
+no1beyondfan888: folds 
+hellokwanny: calls 250
+pokeher878787: calls 200
+*** FLOP *** [5s 4h Ad]
+hellokwanny: bets 300
+pokeher878787: calls 300
+420justblazeit: calls 300
+*** TURN *** [5s 4h Ad] [4c]
+hellokwanny: bets 850
+pokeher878787: calls 850
+420justblazeit: folds 
+*** RIVER *** [5s 4h Ad 4c] [9d]
+hellokwanny: checks 
+pokeher878787: bets 1653
+hellokwanny: calls 1653
+*** SHOW DOWN ***
+pokeher878787: shows [6s 5d] (two pair, Fives and Fours)
+hellokwanny: shows [Ac Qh] (two pair, Aces and Fours)
+hellokwanny collected 6432 from pot
+*** SUMMARY ***
+Total pot 6806 | Rake 374 
+Board [5s 4h Ad 4c 9d]
+Seat 1: hellokwanny (small blind) showed [Ac Qh] and won (6432) with two pair, Aces and Fours
+Seat 4: pokeher878787 (big blind) showed [6s 5d] and lost with two pair, Fives and Fours
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit folded on the Turn
+Seat 8: winghymliu folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 (button) folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211266334434: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:05:40 WET [2020/04/03 17:05:40 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (33893 in chips) 
+Seat 4: pokeher878787 (14329 in chips) 
+Seat 5: scra88le56 (10217 in chips) 
+Seat 6: 420justblazeit (9317 in chips) 
+Seat 8: winghymliu (7620 in chips) 
+Seat 9: no1beyondfan888 (59716 in chips) 
+pokeher878787: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [4s 9s]
+420justblazeit: folds 
+winghymliu: raises 100 to 200
+no1beyondfan888: calls 200
+hellokwanny: folds 
+pokeher878787: calls 150
+scra88le56: calls 100
+*** FLOP *** [Kc 5h 3d]
+pokeher878787: bets 378
+scra88le56: folds 
+winghymliu: folds 
+no1beyondfan888: calls 378
+*** TURN *** [Kc 5h 3d] [6c]
+pokeher878787: bets 1470
+no1beyondfan888: folds 
+Uncalled bet (1470) returned to pokeher878787
+pokeher878787 collected 1470 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 1556 | Rake 86 
+Board [Kc 5h 3d 6c]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 4: pokeher878787 (small blind) collected (1470)
+Seat 5: scra88le56 (big blind) folded on the Flop
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu folded on the Flop
+Seat 9: no1beyondfan888 folded on the Turn
+
+
+
+PokerStars Home Game Hand #211266452258: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:06:59 WET [2020/04/03 17:06:59 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #4 is the button
+Seat 1: hellokwanny (33893 in chips) 
+Seat 4: pokeher878787 (15221 in chips) 
+Seat 5: scra88le56 (10017 in chips) 
+Seat 6: 420justblazeit (9317 in chips) 
+Seat 8: winghymliu (7420 in chips) 
+Seat 9: no1beyondfan888 (59138 in chips) 
+scra88le56: posts small blind 50
+420justblazeit: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [7s Ac]
+winghymliu: folds 
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: raises 200 to 300
+scra88le56: calls 250
+420justblazeit: folds 
+*** FLOP *** [Qc 3c Td]
+scra88le56: checks 
+pokeher878787: bets 100
+scra88le56: folds 
+Uncalled bet (100) returned to pokeher878787
+pokeher878787 collected 661 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 700 | Rake 39 
+Board [Qc 3c Td]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 (button) collected (661)
+Seat 5: scra88le56 (small blind) folded on the Flop
+Seat 6: 420justblazeit (big blind) folded before Flop
+Seat 8: winghymliu folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211266502038: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:07:33 WET [2020/04/03 17:07:33 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (33893 in chips) 
+Seat 4: pokeher878787 (15582 in chips) 
+Seat 5: scra88le56 (9717 in chips) 
+Seat 6: 420justblazeit (9217 in chips) 
+Seat 8: winghymliu (7420 in chips) 
+Seat 9: no1beyondfan888 (59138 in chips) 
+420justblazeit: posts small blind 50
+winghymliu: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Ah Qh]
+no1beyondfan888: raises 100 to 200
+hellokwanny: raises 300 to 500
+pokeher878787: calls 500
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: folds 
+no1beyondfan888: calls 300
+*** FLOP *** [4c 4d 9d]
+no1beyondfan888: checks 
+hellokwanny: checks 
+pokeher878787: bets 779
+no1beyondfan888: calls 779
+hellokwanny: folds 
+*** TURN *** [4c 4d 9d] [8d]
+no1beyondfan888: checks 
+pokeher878787: bets 1516
+no1beyondfan888: calls 1516
+*** RIVER *** [4c 4d 9d 8d] [6s]
+no1beyondfan888: checks 
+pokeher878787: checks 
+*** SHOW DOWN ***
+no1beyondfan888: shows [2h 9h] (two pair, Nines and Fours)
+pokeher878787: mucks hand 
+no1beyondfan888 collected 5897 from pot
+*** SUMMARY ***
+Total pot 6240 | Rake 343 
+Board [4c 4d 9d 8d 6s]
+Seat 1: hellokwanny folded on the Flop
+Seat 4: pokeher878787 mucked [Ad Th]
+Seat 5: scra88le56 (button) folded before Flop (didn't bet)
+Seat 6: 420justblazeit (small blind) folded before Flop
+Seat 8: winghymliu (big blind) folded before Flop
+Seat 9: no1beyondfan888 showed [2h 9h] and won (5897) with two pair, Nines and Fours
+
+
+
+PokerStars Home Game Hand #211266588438: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:08:31 WET [2020/04/03 17:08:31 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (33393 in chips) 
+Seat 4: pokeher878787 (12787 in chips) 
+Seat 5: scra88le56 (9717 in chips) 
+Seat 6: 420justblazeit (9167 in chips) 
+Seat 8: winghymliu (7320 in chips) 
+Seat 9: no1beyondfan888 (62240 in chips) 
+winghymliu: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [2d 7h]
+hellokwanny: folds 
+pokeher878787: calls 100
+scra88le56: raises 400 to 500
+420justblazeit: folds 
+winghymliu: raises 1200 to 1700
+no1beyondfan888: folds 
+pokeher878787: folds 
+scra88le56: calls 1200
+*** FLOP *** [9c 4h 2h]
+winghymliu: bets 3402
+scra88le56: raises 4615 to 8017 and is all-in
+winghymliu: calls 2218 and is all-in
+Uncalled bet (2397) returned to scra88le56
+*** TURN *** [9c 4h 2h] [7c]
+*** RIVER *** [9c 4h 2h 7c] [2c]
+*** SHOW DOWN ***
+winghymliu: shows [8h 8d] (two pair, Eights and Deuces)
+scra88le56: shows [6d 6s] (two pair, Sixes and Deuces)
+winghymliu collected 14024 from pot
+*** SUMMARY ***
+Total pot 14840 | Rake 816 
+Board [9c 4h 2h 7c 2c]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 folded before Flop
+Seat 5: scra88le56 showed [6d 6s] and lost with two pair, Sixes and Deuces
+Seat 6: 420justblazeit (button) folded before Flop (didn't bet)
+Seat 8: winghymliu (small blind) showed [8h 8d] and won (14024) with two pair, Eights and Deuces
+Seat 9: no1beyondfan888 (big blind) folded before Flop
+
+
+
+PokerStars Home Game Hand #211266651568: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:09:14 WET [2020/04/03 17:09:14 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (33393 in chips) 
+Seat 4: pokeher878787 (12687 in chips) 
+Seat 5: scra88le56 (2397 in chips) 
+Seat 6: 420justblazeit (9167 in chips) 
+Seat 8: winghymliu (14024 in chips) 
+Seat 9: no1beyondfan888 (62140 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [6d Td]
+pokeher878787: calls 100
+scra88le56: folds 
+420justblazeit: calls 100
+winghymliu: raises 100 to 200
+no1beyondfan888: calls 150
+hellokwanny: folds 
+pokeher878787: calls 100
+420justblazeit: calls 100
+*** FLOP *** [8h 3d 9d]
+no1beyondfan888: checks 
+pokeher878787: checks 
+420justblazeit: bets 425
+winghymliu: calls 425
+no1beyondfan888: calls 425
+pokeher878787: calls 425
+*** TURN *** [8h 3d 9d] [Th]
+no1beyondfan888: bets 2457
+pokeher878787: folds 
+420justblazeit: folds 
+winghymliu: calls 2457
+*** RIVER *** [8h 3d 9d Th] [Jc]
+no1beyondfan888: checks 
+winghymliu: bets 7101
+no1beyondfan888 has timed out
+no1beyondfan888: folds 
+Uncalled bet (7101) returned to winghymliu
+winghymliu collected 7101 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 7514 | Rake 413 
+Board [8h 3d 9d Th Jc]
+Seat 1: hellokwanny (big blind) folded before Flop
+Seat 4: pokeher878787 folded on the Turn
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit folded on the Turn
+Seat 8: winghymliu (button) collected (7101)
+Seat 9: no1beyondfan888 (small blind) folded on the River
+
+
+
+PokerStars Home Game Hand #211266773815: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:10:39 WET [2020/04/03 17:10:39 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (33293 in chips) 
+Seat 4: pokeher878787 (12062 in chips) 
+Seat 5: scra88le56 (2397 in chips) 
+Seat 6: 420justblazeit (8542 in chips) 
+Seat 8: winghymliu (18043 in chips) 
+pokeher878787: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [2h Jh]
+420justblazeit: folds 
+winghymliu: raises 100 to 200
+hellokwanny: folds 
+pokeher878787: raises 100 to 300
+scra88le56: calls 200
+winghymliu: calls 100
+*** FLOP *** [5h Kh Td]
+pokeher878787: bets 425
+scra88le56: raises 850 to 1275
+winghymliu: calls 1275
+pokeher878787: folds 
+*** TURN *** [5h Kh Td] [2d]
+scra88le56: bets 822 and is all-in
+winghymliu: calls 822
+*** RIVER *** [5h Kh Td 2d] [6c]
+*** SHOW DOWN ***
+scra88le56: shows [Ks 4d] (a pair of Kings)
+winghymliu: shows [Ah 7h] (high card Ace)
+scra88le56 collected 5215 from pot
+*** SUMMARY ***
+Total pot 5519 | Rake 304 
+Board [5h Kh Td 2d 6c]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 4: pokeher878787 (small blind) folded on the Flop
+Seat 5: scra88le56 (big blind) showed [Ks 4d] and won (5215) with a pair of Kings
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu showed [Ah 7h] and lost with high card Ace
+
+
+
+PokerStars Home Game Hand #211266863473: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:11:35 WET [2020/04/03 17:11:35 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #4 is the button
+Seat 1: hellokwanny (33293 in chips) 
+Seat 4: pokeher878787 (11337 in chips) 
+Seat 5: scra88le56 (5215 in chips) 
+Seat 6: 420justblazeit (8542 in chips) 
+Seat 8: winghymliu (15646 in chips) 
+Seat 9: no1beyondfan888 (59058 in chips) 
+scra88le56: posts small blind 50
+420justblazeit: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [2h 8h]
+winghymliu: calls 100
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: calls 100
+scra88le56: calls 50
+420justblazeit: checks 
+*** FLOP *** [Qs Ah 4c]
+scra88le56: checks 
+420justblazeit: checks 
+winghymliu: checks 
+pokeher878787: checks 
+*** TURN *** [Qs Ah 4c] [3c]
+scra88le56: bets 189
+420justblazeit: raises 189 to 378
+winghymliu: raises 189 to 567
+pokeher878787: folds 
+scra88le56: folds 
+420justblazeit: calls 189
+*** RIVER *** [Qs Ah 4c 3c] [7s]
+420justblazeit: bets 814
+winghymliu: raises 3256 to 4070
+420justblazeit: calls 3256
+*** SHOW DOWN ***
+winghymliu: shows [Js Td] (high card Ace)
+420justblazeit: shows [3d 4s] (two pair, Fours and Threes)
+420justblazeit collected 9321 from pot
+*** SUMMARY ***
+Total pot 9863 | Rake 542 
+Board [Qs Ah 4c 3c 7s]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 (button) folded on the Turn
+Seat 5: scra88le56 (small blind) folded on the Turn
+Seat 6: 420justblazeit (big blind) showed [3d 4s] and won (9321) with two pair, Fours and Threes
+Seat 8: winghymliu showed [Js Td] and lost with high card Ace
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211266991605: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:13:03 WET [2020/04/03 17:13:03 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (33293 in chips) 
+Seat 4: pokeher878787 (11237 in chips) 
+Seat 5: scra88le56 (4926 in chips) 
+Seat 6: 420justblazeit (13126 in chips) 
+Seat 8: winghymliu (10909 in chips) 
+Seat 9: no1beyondfan888 (59058 in chips) 
+420justblazeit: posts small blind 50
+winghymliu: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Kd Kc]
+no1beyondfan888: calls 100
+hellokwanny: raises 300 to 400
+pokeher878787: calls 400
+scra88le56: raises 300 to 700
+420justblazeit: folds 
+winghymliu: folds 
+no1beyondfan888: calls 600
+hellokwanny: calls 300
+pokeher878787: calls 300
+*** FLOP *** [Jh Qs 3c]
+no1beyondfan888: checks 
+hellokwanny: bets 2400
+pokeher878787: folds 
+scra88le56: raises 1826 to 4226 and is all-in
+no1beyondfan888: folds 
+hellokwanny: calls 1826
+*** TURN *** [Jh Qs 3c] [Ts]
+*** RIVER *** [Jh Qs 3c Ts] [Jd]
+*** SHOW DOWN ***
+hellokwanny: shows [Kd Kc] (two pair, Kings and Jacks)
+scra88le56: shows [8s 8c] (two pair, Jacks and Eights)
+hellokwanny collected 10775 from pot
+*** SUMMARY ***
+Total pot 11402 | Rake 627 
+Board [Jh Qs 3c Ts Jd]
+Seat 1: hellokwanny showed [Kd Kc] and won (10775) with two pair, Kings and Jacks
+Seat 4: pokeher878787 folded on the Flop
+Seat 5: scra88le56 (button) showed [8s 8c] and lost with two pair, Jacks and Eights
+Seat 6: 420justblazeit (small blind) folded before Flop
+Seat 8: winghymliu (big blind) folded before Flop
+Seat 9: no1beyondfan888 folded on the Flop
+
+
+
+PokerStars Home Game Hand #211267093753: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:14:12 WET [2020/04/03 17:14:12 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (39142 in chips) 
+Seat 4: pokeher878787 (10537 in chips) 
+Seat 6: 420justblazeit (13076 in chips) 
+Seat 8: winghymliu (10809 in chips) 
+Seat 9: no1beyondfan888 (58358 in chips) 
+winghymliu: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Ts 6d]
+hellokwanny: folds 
+pokeher878787: calls 100
+420justblazeit: folds 
+winghymliu: folds 
+no1beyondfan888: checks 
+*** FLOP *** [2s 5d 4d]
+no1beyondfan888: bets 118
+pokeher878787: calls 118
+*** TURN *** [2s 5d 4d] [Kd]
+no1beyondfan888: bets 229
+pokeher878787: calls 229
+*** RIVER *** [2s 5d 4d Kd] [2c]
+no1beyondfan888: bets 892
+pokeher878787: calls 892
+*** SHOW DOWN ***
+no1beyondfan888: shows [Js 9s] (a pair of Deuces)
+pokeher878787: shows [9d 5s] (two pair, Fives and Deuces)
+pokeher878787 collected 2578 from pot
+*** SUMMARY ***
+Total pot 2728 | Rake 150 
+Board [2s 5d 4d Kd 2c]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 showed [9d 5s] and won (2578) with two pair, Fives and Deuces
+Seat 6: 420justblazeit (button) folded before Flop (didn't bet)
+Seat 8: winghymliu (small blind) folded before Flop
+Seat 9: no1beyondfan888 (big blind) showed [Js 9s] and lost with a pair of Deuces
+
+
+
+PokerStars Home Game Hand #211267154760: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:14:54 WET [2020/04/03 17:14:54 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (39142 in chips) 
+Seat 4: pokeher878787 (11776 in chips) 
+Seat 5: scra88le56 (10000 in chips) 
+Seat 6: 420justblazeit (13076 in chips) 
+Seat 8: winghymliu (10759 in chips) 
+Seat 9: no1beyondfan888 (57019 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Kh 3c]
+pokeher878787: raises 200 to 300
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: calls 300
+no1beyondfan888: calls 250
+hellokwanny: folds 
+*** FLOP *** [Ks 4h 5c]
+no1beyondfan888: bets 100
+pokeher878787: calls 100
+winghymliu: calls 100
+*** TURN *** [Ks 4h 5c] [Tc]
+no1beyondfan888: bets 614
+pokeher878787: calls 614
+winghymliu: calls 614
+*** RIVER *** [Ks 4h 5c Tc] [9c]
+no1beyondfan888: checks 
+pokeher878787: bets 400
+winghymliu: raises 3769 to 4169
+no1beyondfan888: raises 3769 to 7938
+pokeher878787: raises 2824 to 10762 and is all-in
+winghymliu: calls 5576 and is all-in
+no1beyondfan888: calls 2824
+*** SHOW DOWN ***
+pokeher878787: shows [Qd Jc] (a straight, Nine to King)
+no1beyondfan888: shows [5s Kc] (two pair, Kings and Fives)
+pokeher878787 collected 1922 from side pot
+winghymliu: shows [Qh Jd] (a straight, Nine to King)
+pokeher878787 collected 15298 from main pot
+winghymliu collected 15298 from main pot
+*** SUMMARY ***
+Total pot 34411 Main pot 30596. Side pot 1922. | Rake 1893 
+Board [Ks 4h 5c Tc 9c]
+Seat 1: hellokwanny (big blind) folded before Flop
+Seat 4: pokeher878787 showed [Qd Jc] and won (17220) with a straight, Nine to King
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu (button) showed [Qh Jd] and won (15298) with a straight, Nine to King
+Seat 9: no1beyondfan888 (small blind) showed [5s Kc] and lost with two pair, Kings and Fives
+
+
+
+PokerStars Home Game Hand #211267278809: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:16:18 WET [2020/04/03 17:16:18 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (39042 in chips) 
+Seat 4: pokeher878787 (17220 in chips) 
+Seat 5: scra88le56 (10000 in chips) 
+Seat 6: 420justblazeit (13076 in chips) 
+Seat 8: winghymliu (15298 in chips) 
+Seat 9: no1beyondfan888 (45243 in chips) 
+hellokwanny: posts small blind 50
+pokeher878787: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [3c Qs]
+scra88le56: calls 100
+420justblazeit: folds 
+winghymliu: calls 100
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: raises 200 to 300
+scra88le56: calls 200
+winghymliu: calls 200
+*** FLOP *** [5s Td Ts]
+pokeher878787: bets 100
+scra88le56: folds 
+winghymliu: calls 100
+*** TURN *** [5s Td Ts] [5d]
+pokeher878787: bets 543
+winghymliu: folds 
+Uncalled bet (543) returned to pokeher878787
+pokeher878787 collected 1087 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 1150 | Rake 63 
+Board [5s Td Ts 5d]
+Seat 1: hellokwanny (small blind) folded before Flop
+Seat 4: pokeher878787 (big blind) collected (1087)
+Seat 5: scra88le56 folded on the Flop
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu folded on the Turn
+Seat 9: no1beyondfan888 (button) folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211267371955: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:17:21 WET [2020/04/03 17:17:21 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (38992 in chips) 
+Seat 4: pokeher878787 (17907 in chips) 
+Seat 5: scra88le56 (9700 in chips) 
+Seat 6: 420justblazeit (13076 in chips) 
+Seat 8: winghymliu (14898 in chips) 
+Seat 9: no1beyondfan888 (45243 in chips) 
+pokeher878787: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [6s 2d]
+420justblazeit: folds 
+winghymliu: folds 
+no1beyondfan888: calls 100
+hellokwanny: folds 
+pokeher878787: calls 50
+scra88le56: checks 
+*** FLOP *** [Th Qh Jh]
+pokeher878787: bets 100
+scra88le56: calls 100
+no1beyondfan888: calls 100
+*** TURN *** [Th Qh Jh] [3h]
+pokeher878787: bets 100
+scra88le56: calls 100
+no1beyondfan888: raises 100 to 200
+pokeher878787: folds 
+scra88le56: raises 400 to 600
+no1beyondfan888: calls 400
+*** RIVER *** [Th Qh Jh 3h] [Ks]
+scra88le56: bets 897
+no1beyondfan888: calls 897
+*** SHOW DOWN ***
+scra88le56: shows [3d Ah] (a flush, Ace high)
+no1beyondfan888: mucks hand 
+scra88le56 collected 3491 from pot
+*** SUMMARY ***
+Total pot 3694 | Rake 203 
+Board [Th Qh Jh 3h Ks]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 4: pokeher878787 (small blind) folded on the Turn
+Seat 5: scra88le56 (big blind) showed [3d Ah] and won (3491) with a flush, Ace high
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 mucked [Ad 8h]
+
+
+
+PokerStars Home Game Hand #211267454327: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:18:19 WET [2020/04/03 17:18:19 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #4 is the button
+Seat 1: hellokwanny (38992 in chips) 
+Seat 4: pokeher878787 (17607 in chips) 
+Seat 5: scra88le56 (11494 in chips) 
+Seat 6: 420justblazeit (13076 in chips) 
+Seat 8: winghymliu (14898 in chips) 
+Seat 9: no1beyondfan888 (43546 in chips) 
+scra88le56: posts small blind 50
+420justblazeit: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [6h 5h]
+winghymliu: folds 
+no1beyondfan888: calls 100
+hellokwanny: calls 100
+pokeher878787: raises 200 to 300
+scra88le56: calls 250
+420justblazeit: folds 
+no1beyondfan888: calls 200
+hellokwanny: calls 200
+*** FLOP *** [4d 8s Kd]
+scra88le56: checks 
+no1beyondfan888: bets 100
+hellokwanny: calls 100
+pokeher878787: calls 100
+scra88le56: calls 100
+*** TURN *** [4d 8s Kd] [Qd]
+scra88le56: checks 
+no1beyondfan888: checks 
+hellokwanny: checks 
+pokeher878787: bets 100
+scra88le56: raises 2800 to 2900
+no1beyondfan888: calls 2900
+hellokwanny: folds 
+pokeher878787: folds 
+*** RIVER *** [4d 8s Kd Qd] [5s]
+scra88le56: checks 
+no1beyondfan888: bets 7182
+scra88le56: raises 1012 to 8194 and is all-in
+no1beyondfan888: calls 1012
+*** SHOW DOWN ***
+scra88le56: shows [Tc Qc] (a pair of Queens)
+no1beyondfan888: shows [9d 8c] (a pair of Eights)
+scra88le56 collected 22669 from pot
+*** SUMMARY ***
+Total pot 23988 | Rake 1319 
+Board [4d 8s Kd Qd 5s]
+Seat 1: hellokwanny folded on the Turn
+Seat 4: pokeher878787 (button) folded on the Turn
+Seat 5: scra88le56 (small blind) showed [Tc Qc] and won (22669) with a pair of Queens
+Seat 6: 420justblazeit (big blind) folded before Flop
+Seat 8: winghymliu folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 showed [9d 8c] and lost with a pair of Eights
+
+
+
+PokerStars Home Game Hand #211267562424: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:19:33 WET [2020/04/03 17:19:33 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (38592 in chips) 
+Seat 4: pokeher878787 (17107 in chips) 
+Seat 5: scra88le56 (22669 in chips) 
+Seat 6: 420justblazeit (12976 in chips) 
+Seat 8: winghymliu (14898 in chips) 
+Seat 9: no1beyondfan888 (32052 in chips) 
+420justblazeit: posts small blind 50
+winghymliu: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [3h 4d]
+no1beyondfan888: raises 100 to 200
+hellokwanny: folds 
+pokeher878787: calls 200
+scra88le56: calls 200
+420justblazeit: raises 100 to 300
+winghymliu: folds 
+no1beyondfan888: calls 100
+pokeher878787: calls 100
+scra88le56: calls 100
+*** FLOP *** [Js Kd Qc]
+420justblazeit: bets 614
+no1beyondfan888: folds 
+pokeher878787: raises 614 to 1228
+scra88le56: folds 
+420justblazeit: calls 614
+*** TURN *** [Js Kd Qc] [Qh]
+420justblazeit: checks 
+pokeher878787: bets 3549
+420justblazeit: folds 
+Uncalled bet (3549) returned to pokeher878787
+pokeher878787 collected 3549 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 3756 | Rake 207 
+Board [Js Kd Qc Qh]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 collected (3549)
+Seat 5: scra88le56 (button) folded on the Flop
+Seat 6: 420justblazeit (small blind) folded on the Turn
+Seat 8: winghymliu (big blind) folded before Flop
+Seat 9: no1beyondfan888 folded on the Flop
+
+
+
+PokerStars Home Game Hand #211267696892: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:21:06 WET [2020/04/03 17:21:06 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (38592 in chips) 
+Seat 4: pokeher878787 (19128 in chips) 
+Seat 5: scra88le56 (22369 in chips) 
+Seat 6: 420justblazeit (11448 in chips) 
+Seat 8: winghymliu (14798 in chips) 
+Seat 9: no1beyondfan888 (31752 in chips) 
+winghymliu: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [3s 9s]
+hellokwanny: folds 
+pokeher878787: raises 200 to 300
+scra88le56: folds 
+420justblazeit: calls 300
+winghymliu: folds 
+no1beyondfan888: calls 200
+*** FLOP *** [2c Js 3h]
+no1beyondfan888: checks 
+pokeher878787: bets 898
+420justblazeit: folds 
+no1beyondfan888: folds 
+Uncalled bet (898) returned to pokeher878787
+pokeher878787 collected 898 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 950 | Rake 52 
+Board [2c Js 3h]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 collected (898)
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit (button) folded on the Flop
+Seat 8: winghymliu (small blind) folded before Flop
+Seat 9: no1beyondfan888 (big blind) folded on the Flop
+
+
+
+PokerStars Home Game Hand #211267746601: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:21:41 WET [2020/04/03 17:21:41 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (38592 in chips) 
+Seat 4: pokeher878787 (19726 in chips) 
+Seat 5: scra88le56 (22369 in chips) 
+Seat 6: 420justblazeit (11148 in chips) 
+Seat 8: winghymliu (14748 in chips) 
+Seat 9: no1beyondfan888 (31452 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [6d 8c]
+pokeher878787: calls 100
+scra88le56: raises 400 to 500
+420justblazeit: folds 
+winghymliu: folds 
+no1beyondfan888: calls 450
+hellokwanny: folds 
+pokeher878787: calls 400
+*** FLOP *** [8h 2h Ac]
+no1beyondfan888: checks 
+pokeher878787: bets 100
+scra88le56: raises 856 to 956
+no1beyondfan888: folds 
+pokeher878787: folds 
+Uncalled bet (856) returned to scra88le56
+scra88le56 collected 1701 from pot
+scra88le56: doesn't show hand 
+*** SUMMARY ***
+Total pot 1800 | Rake 99 
+Board [8h 2h Ac]
+Seat 1: hellokwanny (big blind) folded before Flop
+Seat 4: pokeher878787 folded on the Flop
+Seat 5: scra88le56 collected (1701)
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu (button) folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 (small blind) folded on the Flop
+
+
+
+PokerStars Home Game Hand #211267820756: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:22:26 WET [2020/04/03 17:22:26 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (38492 in chips) 
+Seat 4: pokeher878787 (19126 in chips) 
+Seat 5: scra88le56 (23470 in chips) 
+Seat 6: 420justblazeit (11148 in chips) 
+Seat 8: winghymliu (14748 in chips) 
+Seat 9: no1beyondfan888 (30952 in chips) 
+hellokwanny: posts small blind 50
+pokeher878787: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [5c Tc]
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: calls 100
+no1beyondfan888: calls 100
+hellokwanny: folds 
+pokeher878787: raises 200 to 300
+winghymliu: calls 200
+no1beyondfan888: calls 200
+*** FLOP *** [3d 8d Ts]
+pokeher878787: bets 100
+winghymliu: calls 100
+no1beyondfan888: calls 100
+*** TURN *** [3d 8d Ts] [7h]
+pokeher878787: checks 
+winghymliu: checks 
+no1beyondfan888: bets 590
+pokeher878787: folds 
+winghymliu: calls 590
+*** RIVER *** [3d 8d Ts 7h] [9c]
+winghymliu: bets 2296
+no1beyondfan888: raises 2296 to 4592
+winghymliu: raises 9166 to 13758 and is all-in
+no1beyondfan888: calls 9166
+*** SHOW DOWN ***
+winghymliu: shows [3c 6c] (a straight, Six to Ten)
+no1beyondfan888: shows [Qs Jc] (a straight, Eight to Queen)
+no1beyondfan888 collected 28299 from pot
+*** SUMMARY ***
+Total pot 29946 | Rake 1647 
+Board [3d 8d Ts 7h 9c]
+Seat 1: hellokwanny (small blind) folded before Flop
+Seat 4: pokeher878787 (big blind) folded on the Turn
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu showed [3c 6c] and lost with a straight, Six to Ten
+Seat 9: no1beyondfan888 (button) showed [Qs Jc] and won (28299) with a straight, Eight to Queen
+
+
+
+PokerStars Home Game Hand #211267934565: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:23:44 WET [2020/04/03 17:23:44 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (38442 in chips) 
+Seat 4: pokeher878787 (18726 in chips) 
+Seat 5: scra88le56 (23470 in chips) 
+Seat 6: 420justblazeit (11148 in chips) 
+Seat 9: no1beyondfan888 (44503 in chips) 
+pokeher878787: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [6d Ts]
+420justblazeit: raises 200 to 300
+no1beyondfan888: calls 300
+hellokwanny: folds 
+pokeher878787: calls 250
+scra88le56: folds 
+*** FLOP *** [4c 7c 7s]
+pokeher878787: checks 
+420justblazeit: checks 
+no1beyondfan888: checks 
+*** TURN *** [4c 7c 7s] [6h]
+pokeher878787: checks 
+420justblazeit: checks 
+no1beyondfan888: checks 
+*** RIVER *** [4c 7c 7s 6h] [As]
+pokeher878787: checks 
+420justblazeit: checks 
+no1beyondfan888: checks 
+*** SHOW DOWN ***
+pokeher878787: shows [5d Qd] (a pair of Sevens)
+420justblazeit: shows [Jd Kc] (a pair of Sevens - Ace+King kicker)
+no1beyondfan888: shows [2d 2h] (two pair, Sevens and Deuces)
+no1beyondfan888 collected 945 from pot
+*** SUMMARY ***
+Total pot 1000 | Rake 55 
+Board [4c 7c 7s 6h As]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 4: pokeher878787 (small blind) showed [5d Qd] and lost with a pair of Sevens
+Seat 5: scra88le56 (big blind) folded before Flop
+Seat 6: 420justblazeit showed [Jd Kc] and lost with a pair of Sevens
+Seat 9: no1beyondfan888 showed [2d 2h] and won (945) with two pair, Sevens and Deuces
+
+
+
+PokerStars Home Game Hand #211268016630: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:24:38 WET [2020/04/03 17:24:38 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #4 is the button
+Seat 1: hellokwanny (38442 in chips) 
+Seat 4: pokeher878787 (18426 in chips) 
+Seat 5: scra88le56 (23370 in chips) 
+Seat 6: 420justblazeit (10848 in chips) 
+Seat 9: no1beyondfan888 (45148 in chips) 
+scra88le56: posts small blind 50
+420justblazeit: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Jd 2s]
+no1beyondfan888: calls 100
+hellokwanny: folds 
+pokeher878787: calls 100
+scra88le56: calls 50
+420justblazeit: checks 
+*** FLOP *** [8c 9c 4c]
+scra88le56: checks 
+420justblazeit: checks 
+no1beyondfan888: bets 189
+pokeher878787: calls 189
+scra88le56: calls 189
+420justblazeit: folds 
+*** TURN *** [8c 9c 4c] [6d]
+scra88le56: checks 
+no1beyondfan888: bets 457
+pokeher878787: folds 
+scra88le56: calls 457
+*** RIVER *** [8c 9c 4c 6d] [4s]
+scra88le56: checks 
+no1beyondfan888: bets 1778
+scra88le56: folds 
+Uncalled bet (1778) returned to no1beyondfan888
+no1beyondfan888 collected 1778 from pot
+no1beyondfan888: doesn't show hand 
+*** SUMMARY ***
+Total pot 1881 | Rake 103 
+Board [8c 9c 4c 6d 4s]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 (button) folded on the Turn
+Seat 5: scra88le56 (small blind) folded on the River
+Seat 6: 420justblazeit (big blind) folded on the Flop
+Seat 9: no1beyondfan888 collected (1778)
+
+
+
+PokerStars Home Game Hand #211268124071: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:25:52 WET [2020/04/03 17:25:52 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (38442 in chips) 
+Seat 4: pokeher878787 (18137 in chips) 
+Seat 5: scra88le56 (22624 in chips) 
+Seat 6: 420justblazeit (10748 in chips) 
+Seat 8: winghymliu (10000 in chips) 
+Seat 9: no1beyondfan888 (46180 in chips) 
+420justblazeit: posts small blind 50
+winghymliu: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [2c 5c]
+no1beyondfan888: calls 100
+hellokwanny: folds 
+pokeher878787: raises 200 to 300
+scra88le56: raises 200 to 500
+420justblazeit: folds 
+winghymliu: folds 
+no1beyondfan888: calls 400
+pokeher878787: raises 200 to 700
+scra88le56: calls 200
+no1beyondfan888: calls 200
+*** FLOP *** [6d Js 4s]
+no1beyondfan888: checks 
+pokeher878787: bets 1063
+scra88le56: raises 1063 to 2126
+no1beyondfan888: folds 
+pokeher878787: calls 1063
+*** TURN *** [6d Js 4s] [8c]
+pokeher878787: bets 100
+scra88le56: raises 19698 to 19798 and is all-in
+pokeher878787 has timed out
+pokeher878787: folds 
+Uncalled bet (19698) returned to scra88le56
+scra88le56 collected 6333 from pot
+scra88le56: doesn't show hand 
+*** SUMMARY ***
+Total pot 6702 | Rake 369 
+Board [6d Js 4s 8c]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 folded on the Turn
+Seat 5: scra88le56 (button) collected (6333)
+Seat 6: 420justblazeit (small blind) folded before Flop
+Seat 8: winghymliu (big blind) folded before Flop
+Seat 9: no1beyondfan888 folded on the Flop
+
+
+
+PokerStars Home Game Hand #211268219704: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:26:58 WET [2020/04/03 17:26:58 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (38442 in chips) 
+Seat 5: scra88le56 (26031 in chips) 
+Seat 6: 420justblazeit (10698 in chips) 
+Seat 8: winghymliu (9900 in chips) 
+Seat 9: no1beyondfan888 (45480 in chips) 
+winghymliu: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Ks 8c]
+hellokwanny: folds 
+scra88le56: calls 100
+420justblazeit: folds 
+winghymliu: calls 50
+no1beyondfan888: checks 
+*** FLOP *** [Jd 9s Ah]
+winghymliu: checks 
+no1beyondfan888: checks 
+scra88le56: checks 
+*** TURN *** [Jd 9s Ah] [3c]
+winghymliu: bets 283
+no1beyondfan888: folds 
+scra88le56: folds 
+Uncalled bet (283) returned to winghymliu
+winghymliu collected 283 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 300 | Rake 17 
+Board [Jd 9s Ah 3c]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 5: scra88le56 folded on the Turn
+Seat 6: 420justblazeit (button) folded before Flop (didn't bet)
+Seat 8: winghymliu (small blind) collected (283)
+Seat 9: no1beyondfan888 (big blind) folded on the Turn
+
+
+
+PokerStars Home Game Hand #211268276403: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:27:37 WET [2020/04/03 17:27:37 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (38442 in chips) 
+Seat 4: pokeher878787 (15211 in chips) 
+Seat 5: scra88le56 (25931 in chips) 
+Seat 6: 420justblazeit (10698 in chips) 
+Seat 8: winghymliu (10083 in chips) 
+hellokwanny: posts small blind 50
+pokeher878787: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [8s 6d]
+scra88le56: calls 100
+420justblazeit: folds 
+winghymliu: calls 100
+hellokwanny: folds 
+pokeher878787: checks 
+*** FLOP *** [4h Qh 7s]
+pokeher878787: bets 331
+scra88le56: folds 
+winghymliu: folds 
+Uncalled bet (331) returned to pokeher878787
+pokeher878787 collected 331 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 350 | Rake 19 
+Board [4h Qh 7s]
+Seat 1: hellokwanny (small blind) folded before Flop
+Seat 4: pokeher878787 (big blind) collected (331)
+Seat 5: scra88le56 folded on the Flop
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu (button) folded on the Flop
+
+
+
+PokerStars Home Game Hand #211268339147: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:28:22 WET [2020/04/03 17:28:22 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (38392 in chips) 
+Seat 4: pokeher878787 (15442 in chips) 
+Seat 5: scra88le56 (25831 in chips) 
+Seat 6: 420justblazeit (10698 in chips) 
+Seat 8: winghymliu (9983 in chips) 
+pokeher878787: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Tc Qh]
+420justblazeit: folds 
+winghymliu: folds 
+hellokwanny: raises 200 to 300
+pokeher878787: calls 250
+scra88le56: calls 200
+*** FLOP *** [Kd 4c Jc]
+pokeher878787: bets 100
+scra88le56: calls 100
+hellokwanny: raises 300 to 400
+pokeher878787: folds 
+scra88le56: folds 
+Uncalled bet (300) returned to hellokwanny
+hellokwanny collected 1134 from pot
+hellokwanny: doesn't show hand 
+*** SUMMARY ***
+Total pot 1200 | Rake 66 
+Board [Kd 4c Jc]
+Seat 1: hellokwanny (button) collected (1134)
+Seat 4: pokeher878787 (small blind) folded on the Flop
+Seat 5: scra88le56 (big blind) folded on the Flop
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211268388290: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:28:56 WET [2020/04/03 17:28:56 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #4 is the button
+Seat 1: hellokwanny (39126 in chips) 
+Seat 4: pokeher878787 (15042 in chips) 
+Seat 5: scra88le56 (25431 in chips) 
+Seat 6: 420justblazeit (10698 in chips) 
+Seat 8: winghymliu (9983 in chips) 
+scra88le56: posts small blind 50
+420justblazeit: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Qc 4d]
+winghymliu: folds 
+hellokwanny: folds 
+pokeher878787: raises 200 to 300
+scra88le56: folds 
+420justblazeit: calls 200
+*** FLOP *** [Jc As 6s]
+420justblazeit: checks 
+pokeher878787: bets 307
+420justblazeit: calls 307
+*** TURN *** [Jc As 6s] [5s]
+420justblazeit: bets 597
+pokeher878787: raises 2388 to 2985
+420justblazeit: calls 2388
+*** RIVER *** [Jc As 6s 5s] [Ts]
+420justblazeit: checks 
+pokeher878787: bets 11450 and is all-in
+420justblazeit has timed out
+420justblazeit: folds 
+Uncalled bet (11450) returned to pokeher878787
+pokeher878787 collected 6836 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 7234 | Rake 398 
+Board [Jc As 6s 5s Ts]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 (button) collected (6836)
+Seat 5: scra88le56 (small blind) folded before Flop
+Seat 6: 420justblazeit (big blind) folded on the River
+Seat 8: winghymliu folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211268533446: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:30:37 WET [2020/04/03 17:30:37 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (39126 in chips) 
+Seat 4: pokeher878787 (18286 in chips) 
+Seat 5: scra88le56 (25381 in chips) 
+Seat 8: winghymliu (9983 in chips) 
+Seat 9: no1beyondfan888 (45380 in chips) 
+winghymliu: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Jc Ac]
+hellokwanny: raises 300 to 400
+pokeher878787: raises 300 to 700
+scra88le56: folds 
+winghymliu: calls 650
+no1beyondfan888: calls 600
+hellokwanny: calls 300
+*** FLOP *** [7c As 2h]
+winghymliu: checks 
+no1beyondfan888: checks 
+hellokwanny: bets 1323
+pokeher878787: folds 
+winghymliu: folds 
+no1beyondfan888: folds 
+Uncalled bet (1323) returned to hellokwanny
+hellokwanny collected 2646 from pot
+hellokwanny: doesn't show hand 
+*** SUMMARY ***
+Total pot 2800 | Rake 154 
+Board [7c As 2h]
+Seat 1: hellokwanny collected (2646)
+Seat 4: pokeher878787 folded on the Flop
+Seat 5: scra88le56 (button) folded before Flop (didn't bet)
+Seat 8: winghymliu (small blind) folded on the Flop
+Seat 9: no1beyondfan888 (big blind) folded on the Flop
+
+
+
+PokerStars Home Game Hand #211268622144: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:31:38 WET [2020/04/03 17:31:38 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (41072 in chips) 
+Seat 4: pokeher878787 (17586 in chips) 
+Seat 5: scra88le56 (25381 in chips) 
+Seat 6: 420justblazeit (7106 in chips) 
+Seat 8: winghymliu (9283 in chips) 
+Seat 9: no1beyondfan888 (44680 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+420justblazeit: posts small blind 50
+*** HOLE CARDS ***
+Dealt to hellokwanny [Ac 4s]
+pokeher878787: calls 100
+scra88le56: calls 100
+420justblazeit: folds 
+winghymliu: folds 
+no1beyondfan888: calls 50
+hellokwanny: checks 
+*** FLOP *** [Ks 4c Tc]
+no1beyondfan888: checks 
+hellokwanny: bets 200
+pokeher878787: calls 200
+scra88le56: folds 
+no1beyondfan888: folds 
+*** TURN *** [Ks 4c Tc] [7s]
+hellokwanny: checks 
+pokeher878787: bets 803
+hellokwanny: folds 
+Uncalled bet (803) returned to pokeher878787
+pokeher878787 collected 803 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 850 | Rake 47 
+Board [Ks 4c Tc 7s]
+Seat 1: hellokwanny (big blind) folded on the Turn
+Seat 4: pokeher878787 collected (803)
+Seat 5: scra88le56 folded on the Flop
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu (button) folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 (small blind) folded on the Flop
+
+
+
+PokerStars Home Game Hand #211268716702: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:32:44 WET [2020/04/03 17:32:44 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (40772 in chips) 
+Seat 4: pokeher878787 (18089 in chips) 
+Seat 5: scra88le56 (25281 in chips) 
+Seat 6: 420justblazeit (7056 in chips) 
+Seat 8: winghymliu (9283 in chips) 
+Seat 9: no1beyondfan888 (44580 in chips) 
+hellokwanny: posts small blind 50
+pokeher878787: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [9d 4c]
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: folds 
+no1beyondfan888: calls 100
+hellokwanny: folds 
+pokeher878787: checks 
+*** FLOP *** [7h Ks Jh]
+pokeher878787: checks 
+no1beyondfan888: checks 
+*** TURN *** [7h Ks Jh] [Kh]
+pokeher878787: bets 100
+no1beyondfan888: raises 100 to 200
+pokeher878787: calls 100
+*** RIVER *** [7h Ks Jh Kh] [5d]
+pokeher878787: bets 100
+no1beyondfan888: raises 407 to 507
+pokeher878787: calls 407
+*** SHOW DOWN ***
+no1beyondfan888: shows [Qs Ts] (a pair of Kings)
+pokeher878787: shows [5c 6d] (two pair, Kings and Fives)
+pokeher878787 collected 1572 from pot
+*** SUMMARY ***
+Total pot 1664 | Rake 92 
+Board [7h Ks Jh Kh 5d]
+Seat 1: hellokwanny (small blind) folded before Flop
+Seat 4: pokeher878787 (big blind) showed [5c 6d] and won (1572) with two pair, Kings and Fives
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 (button) showed [Qs Ts] and lost with a pair of Kings
+
+
+
+PokerStars Home Game Hand #211268771886: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:33:23 WET [2020/04/03 17:33:23 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (40722 in chips) 
+Seat 4: pokeher878787 (18854 in chips) 
+Seat 5: scra88le56 (25281 in chips) 
+Seat 6: 420justblazeit (7056 in chips) 
+Seat 8: winghymliu (9283 in chips) 
+Seat 9: no1beyondfan888 (43773 in chips) 
+pokeher878787: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [3c Qc]
+420justblazeit: calls 100
+winghymliu: calls 100
+no1beyondfan888: calls 100
+hellokwanny: folds 
+pokeher878787: calls 50
+scra88le56: checks 
+*** FLOP *** [4h 5h Ts]
+pokeher878787: bets 236
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: folds 
+no1beyondfan888: calls 236
+*** TURN *** [4h 5h Ts] [Td]
+pokeher878787: bets 100
+no1beyondfan888: raises 100 to 200
+pokeher878787: calls 100
+*** RIVER *** [4h 5h Ts Td] [Jh]
+pokeher878787: checks 
+no1beyondfan888: bets 1297
+pokeher878787: folds 
+Uncalled bet (1297) returned to no1beyondfan888
+no1beyondfan888 collected 1297 from pot
+no1beyondfan888: doesn't show hand 
+*** SUMMARY ***
+Total pot 1372 | Rake 75 
+Board [4h 5h Ts Td Jh]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 4: pokeher878787 (small blind) folded on the River
+Seat 5: scra88le56 (big blind) folded on the Flop
+Seat 6: 420justblazeit folded on the Flop
+Seat 8: winghymliu folded on the Flop
+Seat 9: no1beyondfan888 collected (1297)
+
+
+
+PokerStars Home Game Hand #211268843403: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:34:13 WET [2020/04/03 17:34:13 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #4 is the button
+Seat 1: hellokwanny (40722 in chips) 
+Seat 4: pokeher878787 (18318 in chips) 
+Seat 5: scra88le56 (25181 in chips) 
+Seat 6: 420justblazeit (6956 in chips) 
+Seat 8: winghymliu (9183 in chips) 
+Seat 9: no1beyondfan888 (44534 in chips) 
+scra88le56: posts small blind 50
+420justblazeit: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Ts 4s]
+winghymliu: calls 100
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: calls 100
+scra88le56: folds 
+420justblazeit: checks 
+*** FLOP *** [3s 6s 6h]
+420justblazeit: checks 
+winghymliu: bets 100
+pokeher878787: folds 
+420justblazeit: calls 100
+*** TURN *** [3s 6s 6h] [9s]
+420justblazeit: checks 
+winghymliu: bets 520
+420justblazeit: calls 520
+*** RIVER *** [3s 6s 6h 9s] [7d]
+420justblazeit: checks 
+winghymliu: bets 1503
+420justblazeit: calls 1503
+*** SHOW DOWN ***
+winghymliu: shows [4h Kh] (a pair of Sixes)
+420justblazeit: shows [5s 3d] (two pair, Sixes and Threes)
+420justblazeit collected 4343 from pot
+*** SUMMARY ***
+Total pot 4596 | Rake 253 
+Board [3s 6s 6h 9s 7d]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 (button) folded on the Flop
+Seat 5: scra88le56 (small blind) folded before Flop
+Seat 6: 420justblazeit (big blind) showed [5s 3d] and won (4343) with two pair, Sixes and Threes
+Seat 8: winghymliu showed [4h Kh] and lost with a pair of Sixes
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211268940759: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:35:20 WET [2020/04/03 17:35:20 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (40722 in chips) 
+Seat 4: pokeher878787 (18218 in chips) 
+Seat 5: scra88le56 (25131 in chips) 
+Seat 6: 420justblazeit (9076 in chips) 
+Seat 8: winghymliu (6960 in chips) 
+Seat 9: no1beyondfan888 (44534 in chips) 
+420justblazeit: posts small blind 50
+winghymliu: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Tc 2d]
+no1beyondfan888: calls 100
+hellokwanny: folds 
+pokeher878787: raises 200 to 300
+scra88le56: calls 300
+420justblazeit: folds 
+winghymliu: folds 
+no1beyondfan888: calls 200
+*** FLOP *** [3c 4s Ad]
+no1beyondfan888: checks 
+pokeher878787: bets 992
+scra88le56: calls 992
+no1beyondfan888: folds 
+*** TURN *** [3c 4s Ad] [7d]
+pokeher878787: bets 2867
+scra88le56: folds 
+Uncalled bet (2867) returned to pokeher878787
+pokeher878787 collected 2867 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 3034 | Rake 167 
+Board [3c 4s Ad 7d]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 collected (2867)
+Seat 5: scra88le56 (button) folded on the Turn
+Seat 6: 420justblazeit (small blind) folded before Flop
+Seat 8: winghymliu (big blind) folded before Flop
+Seat 9: no1beyondfan888 folded on the Flop
+
+
+
+PokerStars Home Game Hand #211269041943: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:36:31 WET [2020/04/03 17:36:31 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (40722 in chips) 
+Seat 4: pokeher878787 (19793 in chips) 
+Seat 5: scra88le56 (23839 in chips) 
+Seat 6: 420justblazeit (9026 in chips) 
+Seat 8: winghymliu (6860 in chips) 
+Seat 9: no1beyondfan888 (44234 in chips) 
+winghymliu: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [4c Jh]
+hellokwanny: folds 
+pokeher878787: raises 100 to 200
+scra88le56: folds 
+420justblazeit: calls 200
+winghymliu: folds 
+no1beyondfan888: calls 100
+*** FLOP *** [8s Jd Qs]
+no1beyondfan888: checks 
+pokeher878787: bets 100
+420justblazeit: calls 100
+no1beyondfan888: folds 
+*** TURN *** [8s Jd Qs] [Qc]
+pokeher878787: bets 401
+420justblazeit: calls 401
+*** RIVER *** [8s Jd Qs Qc] [Ac]
+pokeher878787: bets 780
+420justblazeit: calls 780
+*** SHOW DOWN ***
+pokeher878787: shows [Kh 9d] (a pair of Queens)
+420justblazeit: shows [6s As] (two pair, Aces and Queens)
+420justblazeit collected 3035 from pot
+*** SUMMARY ***
+Total pot 3212 | Rake 177 
+Board [8s Jd Qs Qc Ac]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 showed [Kh 9d] and lost with a pair of Queens
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit (button) showed [6s As] and won (3035) with two pair, Aces and Queens
+Seat 8: winghymliu (small blind) folded before Flop
+Seat 9: no1beyondfan888 (big blind) folded on the Flop
+
+
+
+PokerStars Home Game Hand #211269127639: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:37:31 WET [2020/04/03 17:37:31 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (40722 in chips) 
+Seat 4: pokeher878787 (18312 in chips) 
+Seat 5: scra88le56 (23839 in chips) 
+Seat 6: 420justblazeit (10580 in chips) 
+Seat 8: winghymliu (6810 in chips) 
+Seat 9: no1beyondfan888 (44034 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [4c 5s]
+pokeher878787: raises 200 to 300
+scra88le56: folds 
+420justblazeit: calls 300
+winghymliu: raises 200 to 500
+no1beyondfan888: calls 450
+hellokwanny: folds 
+pokeher878787: raises 200 to 700
+420justblazeit: calls 400
+winghymliu: calls 200
+no1beyondfan888: calls 200
+*** FLOP *** [2h 7d 9d]
+no1beyondfan888: checks 
+pokeher878787: bets 1370
+420justblazeit: folds 
+winghymliu: folds 
+no1beyondfan888: folds 
+Uncalled bet (1370) returned to pokeher878787
+pokeher878787 collected 2740 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 2900 | Rake 160 
+Board [2h 7d 9d]
+Seat 1: hellokwanny (big blind) folded before Flop
+Seat 4: pokeher878787 collected (2740)
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit folded on the Flop
+Seat 8: winghymliu (button) folded on the Flop
+Seat 9: no1beyondfan888 (small blind) folded on the Flop
+
+
+
+PokerStars Home Game Hand #211269215985: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:38:33 WET [2020/04/03 17:38:33 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (40622 in chips) 
+Seat 4: pokeher878787 (20352 in chips) 
+Seat 5: scra88le56 (23839 in chips) 
+Seat 6: 420justblazeit (9880 in chips) 
+Seat 8: winghymliu (6110 in chips) 
+Seat 9: no1beyondfan888 (43334 in chips) 
+hellokwanny: posts small blind 50
+pokeher878787: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Th 6c]
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: folds 
+no1beyondfan888: folds 
+hellokwanny: folds 
+Uncalled bet (50) returned to pokeher878787
+pokeher878787 collected 100 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 100 | Rake 0 
+Seat 1: hellokwanny (small blind) folded before Flop
+Seat 4: pokeher878787 (big blind) collected (100)
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 (button) folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211269242418: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:38:51 WET [2020/04/03 17:38:51 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (40572 in chips) 
+Seat 4: pokeher878787 (20402 in chips) 
+Seat 5: scra88le56 (23839 in chips) 
+Seat 6: 420justblazeit (9880 in chips) 
+Seat 8: winghymliu (6110 in chips) 
+Seat 9: no1beyondfan888 (43334 in chips) 
+pokeher878787: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [As 8h]
+420justblazeit: folds 
+winghymliu: calls 100
+no1beyondfan888: calls 100
+hellokwanny: calls 100
+pokeher878787: calls 50
+scra88le56: checks 
+*** FLOP *** [8s Ad 7s]
+pokeher878787: bets 236
+scra88le56: calls 236
+winghymliu: folds 
+no1beyondfan888: calls 236
+hellokwanny: raises 564 to 800
+pokeher878787: calls 564
+scra88le56: calls 564
+no1beyondfan888: folds 
+*** TURN *** [8s Ad 7s] [3c]
+pokeher878787: bets 100
+scra88le56: calls 100
+hellokwanny: raises 1632 to 1732
+pokeher878787: folds 
+scra88le56: folds 
+Uncalled bet (1632) returned to hellokwanny
+hellokwanny collected 3247 from pot
+hellokwanny: doesn't show hand 
+*** SUMMARY ***
+Total pot 3436 | Rake 189 
+Board [8s Ad 7s 3c]
+Seat 1: hellokwanny (button) collected (3247)
+Seat 4: pokeher878787 (small blind) folded on the Turn
+Seat 5: scra88le56 (big blind) folded on the Turn
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu folded on the Flop
+Seat 9: no1beyondfan888 folded on the Flop
+
+
+
+PokerStars Home Game Hand #211269338425: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:39:59 WET [2020/04/03 17:39:59 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #4 is the button
+Seat 1: hellokwanny (42819 in chips) 
+Seat 4: pokeher878787 (19402 in chips) 
+Seat 5: scra88le56 (22839 in chips) 
+Seat 6: 420justblazeit (9880 in chips) 
+Seat 8: winghymliu (6010 in chips) 
+Seat 9: no1beyondfan888 (42998 in chips) 
+scra88le56: posts small blind 50
+420justblazeit: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Ac 6h]
+winghymliu: folds 
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: calls 100
+scra88le56: calls 50
+420justblazeit: raises 200 to 300
+pokeher878787: calls 200
+scra88le56: calls 200
+*** FLOP *** [9d 8s 5h]
+scra88le56: checks 
+420justblazeit: checks 
+pokeher878787: checks 
+*** TURN *** [9d 8s 5h] [Js]
+scra88le56: checks 
+420justblazeit: checks 
+pokeher878787: checks 
+*** RIVER *** [9d 8s 5h Js] [7c]
+scra88le56: bets 1100
+420justblazeit: folds 
+pokeher878787: folds 
+Uncalled bet (1100) returned to scra88le56
+scra88le56 collected 850 from pot
+scra88le56: doesn't show hand 
+*** SUMMARY ***
+Total pot 900 | Rake 50 
+Board [9d 8s 5h Js 7c]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 (button) folded on the River
+Seat 5: scra88le56 (small blind) collected (850)
+Seat 6: 420justblazeit (big blind) folded on the River
+Seat 8: winghymliu folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211269420916: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:40:49 WET [2020/04/03 17:40:49 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (42819 in chips) 
+Seat 4: pokeher878787 (19102 in chips) 
+Seat 5: scra88le56 (23389 in chips) 
+Seat 6: 420justblazeit (9580 in chips) 
+Seat 8: winghymliu (6010 in chips) 
+Seat 9: no1beyondfan888 (42998 in chips) 
+420justblazeit: posts small blind 50
+winghymliu: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [8d Qd]
+no1beyondfan888: raises 100 to 200
+hellokwanny: folds 
+pokeher878787: raises 100 to 300
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: raises 100 to 400
+no1beyondfan888: calls 200
+pokeher878787: calls 100
+*** FLOP *** [3h Qc 4d]
+winghymliu: bets 1181
+no1beyondfan888: folds 
+pokeher878787: folds 
+Uncalled bet (1181) returned to winghymliu
+winghymliu collected 1181 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 1250 | Rake 69 
+Board [3h Qc 4d]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 folded on the Flop
+Seat 5: scra88le56 (button) folded before Flop (didn't bet)
+Seat 6: 420justblazeit (small blind) folded before Flop
+Seat 8: winghymliu (big blind) collected (1181)
+Seat 9: no1beyondfan888 folded on the Flop
+
+
+
+PokerStars Home Game Hand #211269499089: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:41:44 WET [2020/04/03 17:41:44 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (42819 in chips) 
+Seat 4: pokeher878787 (18702 in chips) 
+Seat 5: scra88le56 (23389 in chips) 
+Seat 6: 420justblazeit (9530 in chips) 
+Seat 8: winghymliu (6791 in chips) 
+Seat 9: no1beyondfan888 (42598 in chips) 
+winghymliu: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [2c 2h]
+hellokwanny: raises 200 to 300
+pokeher878787: calls 300
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: calls 250
+no1beyondfan888: calls 200
+*** FLOP *** [5s Td Ts]
+winghymliu: checks 
+no1beyondfan888: checks 
+hellokwanny: checks 
+pokeher878787: bets 100
+winghymliu: calls 100
+no1beyondfan888: calls 100
+hellokwanny: calls 100
+*** TURN *** [5s Td Ts] [8s]
+winghymliu: checks 
+no1beyondfan888: bets 756
+hellokwanny: folds 
+pokeher878787: folds 
+winghymliu: calls 756
+*** RIVER *** [5s Td Ts 8s] [Ks]
+winghymliu: bets 1470
+no1beyondfan888: calls 1470
+*** SHOW DOWN ***
+winghymliu: shows [5d Qd] (two pair, Tens and Fives)
+no1beyondfan888: shows [Ad 2s] (a flush, King high)
+no1beyondfan888 collected 5719 from pot
+*** SUMMARY ***
+Total pot 6052 | Rake 333 
+Board [5s Td Ts 8s Ks]
+Seat 1: hellokwanny folded on the Turn
+Seat 4: pokeher878787 folded on the Turn
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit (button) folded before Flop (didn't bet)
+Seat 8: winghymliu (small blind) showed [5d Qd] and lost with two pair, Tens and Fives
+Seat 9: no1beyondfan888 (big blind) showed [Ad 2s] and won (5719) with a flush, King high
+
+
+
+PokerStars Home Game Hand #211269589560: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:42:49 WET [2020/04/03 17:42:49 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (42419 in chips) 
+Seat 4: pokeher878787 (18302 in chips) 
+Seat 5: scra88le56 (23389 in chips) 
+Seat 6: 420justblazeit (9530 in chips) 
+Seat 8: winghymliu (4165 in chips) 
+Seat 9: no1beyondfan888 (45691 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [2c 8s]
+pokeher878787: raises 200 to 300
+scra88le56: raises 200 to 500
+420justblazeit: folds 
+winghymliu: calls 500
+no1beyondfan888: calls 450
+hellokwanny: folds 
+pokeher878787: calls 200
+*** FLOP *** [5d 6c 2d]
+no1beyondfan888: checks 
+pokeher878787: bets 100
+scra88le56: calls 100
+winghymliu: calls 100
+no1beyondfan888: calls 100
+*** TURN *** [5d 6c 2d] [8c]
+no1beyondfan888: checks 
+pokeher878787: bets 100
+scra88le56: raises 2562 to 2662
+winghymliu: calls 2662
+no1beyondfan888: folds 
+pokeher878787: folds 
+*** RIVER *** [5d 6c 2d 8c] [Qd]
+scra88le56: bets 20127 and is all-in
+winghymliu: calls 903 and is all-in
+Uncalled bet (19224) returned to scra88le56
+*** SHOW DOWN ***
+scra88le56: shows [Th 8h] (a pair of Eights)
+winghymliu: shows [Ac 7h] (high card Ace)
+scra88le56 collected 9195 from pot
+*** SUMMARY ***
+Total pot 9730 | Rake 535 
+Board [5d 6c 2d 8c Qd]
+Seat 1: hellokwanny (big blind) folded before Flop
+Seat 4: pokeher878787 folded on the Turn
+Seat 5: scra88le56 showed [Th 8h] and won (9195) with a pair of Eights
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu (button) showed [Ac 7h] and lost with high card Ace
+Seat 9: no1beyondfan888 (small blind) folded on the Turn
+
+
+
+PokerStars Home Game Hand #211269714065: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:44:17 WET [2020/04/03 17:44:17 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (42319 in chips) 
+Seat 4: pokeher878787 (17602 in chips) 
+Seat 5: scra88le56 (28419 in chips) 
+Seat 6: 420justblazeit (9530 in chips) 
+Seat 9: no1beyondfan888 (45091 in chips) 
+hellokwanny: posts small blind 50
+pokeher878787: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Qd 4d]
+scra88le56: folds 
+420justblazeit: calls 100
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: checks 
+*** FLOP *** [6s 2h Th]
+pokeher878787: bets 100
+420justblazeit: calls 100
+*** TURN *** [6s 2h Th] [4s]
+pokeher878787: bets 212
+420justblazeit: calls 212
+*** RIVER *** [6s 2h Th 4s] [7d]
+pokeher878787: bets 413
+420justblazeit: folds 
+Uncalled bet (413) returned to pokeher878787
+pokeher878787 collected 826 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 874 | Rake 48 
+Board [6s 2h Th 4s 7d]
+Seat 1: hellokwanny (small blind) folded before Flop
+Seat 4: pokeher878787 (big blind) collected (826)
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit folded on the River
+Seat 9: no1beyondfan888 (button) folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211269769476: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:44:57 WET [2020/04/03 17:44:57 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (42269 in chips) 
+Seat 4: pokeher878787 (18016 in chips) 
+Seat 5: scra88le56 (28419 in chips) 
+Seat 6: 420justblazeit (9118 in chips) 
+Seat 9: no1beyondfan888 (45091 in chips) 
+pokeher878787: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [9d Kc]
+420justblazeit: raises 200 to 300
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: folds 
+scra88le56: calls 200
+*** FLOP *** [Qc 3s Ks]
+scra88le56: checks 
+420justblazeit: checks 
+*** TURN *** [Qc 3s Ks] [5h]
+scra88le56: bets 100
+420justblazeit: calls 100
+*** RIVER *** [Qc 3s Ks 5h] [6d]
+scra88le56: bets 200
+420justblazeit: folds 
+Uncalled bet (200) returned to scra88le56
+scra88le56 collected 803 from pot
+scra88le56: doesn't show hand 
+*** SUMMARY ***
+Total pot 850 | Rake 47 
+Board [Qc 3s Ks 5h 6d]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 4: pokeher878787 (small blind) folded before Flop
+Seat 5: scra88le56 (big blind) collected (803)
+Seat 6: 420justblazeit folded on the River
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211269823242: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:45:35 WET [2020/04/03 17:45:35 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #4 is the button
+Seat 1: hellokwanny (42269 in chips) 
+Seat 4: pokeher878787 (17966 in chips) 
+Seat 5: scra88le56 (28822 in chips) 
+Seat 6: 420justblazeit (8718 in chips) 
+Seat 8: winghymliu (10000 in chips) 
+Seat 9: no1beyondfan888 (45091 in chips) 
+scra88le56: posts small blind 50
+420justblazeit: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Ks 4c]
+winghymliu: folds 
+no1beyondfan888: calls 100
+hellokwanny: folds 
+pokeher878787: calls 100
+scra88le56: folds 
+420justblazeit: raises 200 to 300
+no1beyondfan888: calls 200
+pokeher878787: calls 200
+*** FLOP *** [2s 8c Qs]
+420justblazeit: bets 449
+no1beyondfan888: calls 449
+pokeher878787: folds 
+*** TURN *** [2s 8c Qs] [8d]
+420justblazeit: checks 
+no1beyondfan888: checks 
+*** RIVER *** [2s 8c Qs 8d] [Js]
+420justblazeit: bets 873
+no1beyondfan888: calls 873
+*** SHOW DOWN ***
+420justblazeit: shows [Qd Jc] (two pair, Queens and Jacks)
+no1beyondfan888: mucks hand 
+420justblazeit collected 3396 from pot
+*** SUMMARY ***
+Total pot 3594 | Rake 198 
+Board [2s 8c Qs 8d Js]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 (button) folded on the Flop
+Seat 5: scra88le56 (small blind) folded before Flop
+Seat 6: 420justblazeit (big blind) showed [Qd Jc] and won (3396) with two pair, Queens and Jacks
+Seat 8: winghymliu folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 mucked [Ah Tc]
+
+
+
+PokerStars Home Game Hand #211269914410: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:46:41 WET [2020/04/03 17:46:41 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (42269 in chips) 
+Seat 4: pokeher878787 (17666 in chips) 
+Seat 5: scra88le56 (28772 in chips) 
+Seat 6: 420justblazeit (10492 in chips) 
+Seat 8: winghymliu (10000 in chips) 
+Seat 9: no1beyondfan888 (43469 in chips) 
+420justblazeit: posts small blind 50
+winghymliu: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Kd 6c]
+no1beyondfan888: calls 100
+hellokwanny: folds 
+pokeher878787: calls 100
+scra88le56: folds 
+420justblazeit: raises 200 to 300
+winghymliu: raises 800 to 1100
+no1beyondfan888: folds 
+pokeher878787: folds 
+420justblazeit: folds 
+Uncalled bet (800) returned to winghymliu
+winghymliu collected 800 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 800 | Rake 0 
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 folded before Flop
+Seat 5: scra88le56 (button) folded before Flop (didn't bet)
+Seat 6: 420justblazeit (small blind) folded before Flop
+Seat 8: winghymliu (big blind) collected (800)
+Seat 9: no1beyondfan888 folded before Flop
+
+
+
+PokerStars Home Game Hand #211269964247: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:47:16 WET [2020/04/03 17:47:16 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (42269 in chips) 
+Seat 4: pokeher878787 (17566 in chips) 
+Seat 5: scra88le56 (28772 in chips) 
+Seat 6: 420justblazeit (10192 in chips) 
+Seat 8: winghymliu (10500 in chips) 
+Seat 9: no1beyondfan888 (43369 in chips) 
+winghymliu: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [8d 2d]
+hellokwanny: folds 
+pokeher878787: calls 100
+scra88le56: calls 100
+420justblazeit: folds 
+winghymliu: calls 50
+no1beyondfan888: checks 
+*** FLOP *** [9c 9s 7d]
+winghymliu: bets 378
+no1beyondfan888: calls 378
+pokeher878787: folds 
+scra88le56: folds 
+*** TURN *** [9c 9s 7d] [Ah]
+winghymliu: bets 100
+no1beyondfan888: raises 646 to 746
+winghymliu: folds 
+Uncalled bet (646) returned to no1beyondfan888
+no1beyondfan888 collected 1281 from pot
+no1beyondfan888: doesn't show hand 
+*** SUMMARY ***
+Total pot 1356 | Rake 75 
+Board [9c 9s 7d Ah]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 folded on the Flop
+Seat 5: scra88le56 folded on the Flop
+Seat 6: 420justblazeit (button) folded before Flop (didn't bet)
+Seat 8: winghymliu (small blind) folded on the Turn
+Seat 9: no1beyondfan888 (big blind) collected (1281)
+
+
+
+PokerStars Home Game Hand #211270047473: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:48:17 WET [2020/04/03 17:48:17 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (42269 in chips) 
+Seat 4: pokeher878787 (17466 in chips) 
+Seat 5: scra88le56 (28672 in chips) 
+Seat 6: 420justblazeit (10192 in chips) 
+Seat 8: winghymliu (9922 in chips) 
+Seat 9: no1beyondfan888 (44072 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [7h 2h]
+pokeher878787: calls 100
+scra88le56: raises 400 to 500
+420justblazeit: calls 500
+winghymliu: calls 500
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: calls 400
+*** FLOP *** [Tc Qd Kc]
+pokeher878787: checks 
+scra88le56: bets 1000
+420justblazeit: raises 8692 to 9692 and is all-in
+winghymliu: calls 9422 and is all-in
+pokeher878787: folds 
+scra88le56: folds 
+Uncalled bet (270) returned to 420justblazeit
+*** TURN *** [Tc Qd Kc] [9d]
+*** RIVER *** [Tc Qd Kc 9d] [Th]
+*** SHOW DOWN ***
+420justblazeit: shows [Kh As] (two pair, Kings and Tens)
+winghymliu: shows [7c Ac] (a pair of Tens)
+420justblazeit collected 20784 from pot
+*** SUMMARY ***
+Total pot 21994 | Rake 1210 
+Board [Tc Qd Kc 9d Th]
+Seat 1: hellokwanny (big blind) folded before Flop
+Seat 4: pokeher878787 folded on the Flop
+Seat 5: scra88le56 folded on the Flop
+Seat 6: 420justblazeit showed [Kh As] and won (20784) with two pair, Kings and Tens
+Seat 8: winghymliu (button) showed [7c Ac] and lost with a pair of Tens
+Seat 9: no1beyondfan888 (small blind) folded before Flop
+
+
+
+PokerStars Home Game Hand #211270146911: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:49:29 WET [2020/04/03 17:49:29 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (42169 in chips) 
+Seat 4: pokeher878787 (16966 in chips) 
+Seat 5: scra88le56 (27172 in chips) 
+Seat 6: 420justblazeit (21054 in chips) 
+Seat 9: no1beyondfan888 (44022 in chips) 
+hellokwanny: posts small blind 50
+pokeher878787: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [7d Ac]
+scra88le56: folds 
+420justblazeit: folds 
+no1beyondfan888: calls 100
+hellokwanny: folds 
+pokeher878787: checks 
+*** FLOP *** [2d 6d Qh]
+pokeher878787: checks 
+no1beyondfan888: bets 118
+pokeher878787: calls 118
+*** TURN *** [2d 6d Qh] [Kd]
+pokeher878787: checks 
+no1beyondfan888: bets 459
+pokeher878787: folds 
+Uncalled bet (459) returned to no1beyondfan888
+no1beyondfan888 collected 459 from pot
+no1beyondfan888: doesn't show hand 
+*** SUMMARY ***
+Total pot 486 | Rake 27 
+Board [2d 6d Qh Kd]
+Seat 1: hellokwanny (small blind) folded before Flop
+Seat 4: pokeher878787 (big blind) folded on the Turn
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 (button) collected (459)
+
+
+
+PokerStars Home Game Hand #211270192614: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:50:03 WET [2020/04/03 17:50:03 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (42119 in chips) 
+Seat 4: pokeher878787 (16748 in chips) 
+Seat 5: scra88le56 (27172 in chips) 
+Seat 6: 420justblazeit (21054 in chips) 
+Seat 9: no1beyondfan888 (44263 in chips) 
+pokeher878787: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [4c 3d]
+420justblazeit: folds 
+no1beyondfan888: calls 100
+hellokwanny: folds 
+pokeher878787: raises 200 to 300
+scra88le56: calls 200
+no1beyondfan888: calls 200
+*** FLOP *** [Qd 4h 3h]
+pokeher878787: bets 425
+scra88le56: folds 
+no1beyondfan888: raises 425 to 850
+pokeher878787: calls 425
+*** TURN *** [Qd 4h 3h] [5c]
+pokeher878787: checks 
+no1beyondfan888: bets 2457
+pokeher878787: folds 
+Uncalled bet (2457) returned to no1beyondfan888
+no1beyondfan888 collected 2457 from pot
+no1beyondfan888: doesn't show hand 
+*** SUMMARY ***
+Total pot 2600 | Rake 143 
+Board [Qd 4h 3h 5c]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 4: pokeher878787 (small blind) folded on the Turn
+Seat 5: scra88le56 (big blind) folded on the Flop
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 collected (2457)
+
+
+
+PokerStars Home Game Hand #211270268314: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:50:54 WET [2020/04/03 17:50:54 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #4 is the button
+Seat 1: hellokwanny (42119 in chips) 
+Seat 4: pokeher878787 (15598 in chips) 
+Seat 5: scra88le56 (26872 in chips) 
+Seat 6: 420justblazeit (21054 in chips) 
+Seat 9: no1beyondfan888 (45570 in chips) 
+scra88le56: posts small blind 50
+420justblazeit: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Ad 8s]
+no1beyondfan888: raises 100 to 200
+hellokwanny: calls 200
+pokeher878787: calls 200
+scra88le56: calls 150
+420justblazeit: calls 100
+*** FLOP *** [5c Jd 6h]
+scra88le56: checks 
+420justblazeit: checks 
+no1beyondfan888: checks 
+hellokwanny: checks 
+pokeher878787: bets 100
+scra88le56: calls 100
+420justblazeit: folds 
+no1beyondfan888: calls 100
+hellokwanny: folds 
+*** TURN *** [5c Jd 6h] [6d]
+scra88le56: bets 614
+no1beyondfan888: folds 
+pokeher878787: folds 
+Uncalled bet (614) returned to scra88le56
+scra88le56 collected 1228 from pot
+scra88le56: doesn't show hand 
+*** SUMMARY ***
+Total pot 1300 | Rake 72 
+Board [5c Jd 6h 6d]
+Seat 1: hellokwanny folded on the Flop
+Seat 4: pokeher878787 (button) folded on the Turn
+Seat 5: scra88le56 (small blind) collected (1228)
+Seat 6: 420justblazeit (big blind) folded on the Flop
+Seat 9: no1beyondfan888 folded on the Turn
+
+
+
+PokerStars Home Game Hand #211270338365: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:51:46 WET [2020/04/03 17:51:46 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (41919 in chips) 
+Seat 4: pokeher878787 (15298 in chips) 
+Seat 5: scra88le56 (27800 in chips) 
+Seat 6: 420justblazeit (20854 in chips) 
+Seat 9: no1beyondfan888 (45270 in chips) 
+420justblazeit: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [3s Qs]
+hellokwanny: folds 
+pokeher878787: calls 100
+scra88le56: calls 100
+420justblazeit: calls 50
+no1beyondfan888: raises 100 to 200
+pokeher878787: calls 100
+scra88le56: calls 100
+420justblazeit: calls 100
+*** FLOP *** [Kh 2s 2d]
+420justblazeit: checks 
+no1beyondfan888: checks 
+pokeher878787: checks 
+scra88le56: bets 378
+420justblazeit: folds 
+no1beyondfan888: folds 
+pokeher878787: folds 
+Uncalled bet (378) returned to scra88le56
+scra88le56 collected 756 from pot
+scra88le56: doesn't show hand 
+*** SUMMARY ***
+Total pot 800 | Rake 44 
+Board [Kh 2s 2d]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 folded on the Flop
+Seat 5: scra88le56 (button) collected (756)
+Seat 6: 420justblazeit (small blind) folded on the Flop
+Seat 9: no1beyondfan888 (big blind) folded on the Flop
+
+
+
+PokerStars Home Game Hand #211270405477: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:52:35 WET [2020/04/03 17:52:35 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (41919 in chips) 
+Seat 4: pokeher878787 (15098 in chips) 
+Seat 5: scra88le56 (28356 in chips) 
+Seat 6: 420justblazeit (20654 in chips) 
+Seat 9: no1beyondfan888 (45070 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [4c 9d]
+pokeher878787: raises 200 to 300
+scra88le56: folds 
+420justblazeit: folds 
+no1beyondfan888: calls 250
+hellokwanny: folds 
+*** FLOP *** [Ah 9s Qh]
+no1beyondfan888: checks 
+pokeher878787: bets 330
+no1beyondfan888: folds 
+Uncalled bet (330) returned to pokeher878787
+pokeher878787 collected 661 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 700 | Rake 39 
+Board [Ah 9s Qh]
+Seat 1: hellokwanny (big blind) folded before Flop
+Seat 4: pokeher878787 collected (661)
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit (button) folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 (small blind) folded on the Flop
+
+
+
+PokerStars Home Game Hand #211270428330: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:52:52 WET [2020/04/03 17:52:52 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (41819 in chips) 
+Seat 4: pokeher878787 (15459 in chips) 
+Seat 5: scra88le56 (28356 in chips) 
+Seat 6: 420justblazeit (20654 in chips) 
+Seat 9: no1beyondfan888 (44770 in chips) 
+hellokwanny: posts small blind 50
+pokeher878787: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [3h 7h]
+scra88le56: raises 100 to 200
+420justblazeit: raises 400 to 600
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: folds 
+scra88le56: calls 400
+*** FLOP *** [As 7s Js]
+scra88le56: checks 
+420justblazeit: checks 
+*** TURN *** [As 7s Js] [8c]
+scra88le56: checks 
+420justblazeit: checks 
+*** RIVER *** [As 7s Js 8c] [3c]
+scra88le56: checks 
+420justblazeit: bets 500
+scra88le56: calls 500
+*** SHOW DOWN ***
+420justblazeit: shows [Qd Qc] (a pair of Queens)
+scra88le56: mucks hand 
+420justblazeit collected 2221 from pot
+*** SUMMARY ***
+Total pot 2350 | Rake 129 
+Board [As 7s Js 8c 3c]
+Seat 1: hellokwanny (small blind) folded before Flop
+Seat 4: pokeher878787 (big blind) folded before Flop
+Seat 5: scra88le56 mucked [Kd Td]
+Seat 6: 420justblazeit showed [Qd Qc] and won (2221) with a pair of Queens
+Seat 9: no1beyondfan888 (button) folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211270508409: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:53:51 WET [2020/04/03 17:53:51 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (41769 in chips) 
+Seat 4: pokeher878787 (15359 in chips) 
+Seat 5: scra88le56 (27256 in chips) 
+Seat 6: 420justblazeit (21775 in chips) 
+Seat 9: no1beyondfan888 (44770 in chips) 
+pokeher878787: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [2c 6h]
+420justblazeit: folds 
+no1beyondfan888: calls 100
+hellokwanny: folds 
+pokeher878787: raises 200 to 300
+scra88le56: calls 200
+no1beyondfan888: calls 200
+*** FLOP *** [Td 3h 4d]
+pokeher878787: bets 425
+scra88le56: folds 
+no1beyondfan888: calls 425
+*** TURN *** [Td 3h 4d] [8d]
+pokeher878787: bets 1654
+no1beyondfan888: folds 
+Uncalled bet (1654) returned to pokeher878787
+pokeher878787 collected 1654 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 1750 | Rake 96 
+Board [Td 3h 4d 8d]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 4: pokeher878787 (small blind) collected (1654)
+Seat 5: scra88le56 (big blind) folded on the Flop
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 folded on the Turn
+
+
+
+PokerStars Home Game Hand #211270564088: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:54:33 WET [2020/04/03 17:54:33 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #4 is the button
+Seat 1: hellokwanny (41769 in chips) 
+Seat 4: pokeher878787 (16288 in chips) 
+Seat 5: scra88le56 (26956 in chips) 
+Seat 6: 420justblazeit (21775 in chips) 
+Seat 9: no1beyondfan888 (44045 in chips) 
+scra88le56: posts small blind 50
+420justblazeit: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [3c Kd]
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: calls 100
+scra88le56: folds 
+420justblazeit: raises 200 to 300
+pokeher878787: calls 200
+*** FLOP *** [6c 2c Ts]
+420justblazeit: checks 
+pokeher878787: checks 
+*** TURN *** [6c 2c Ts] [4c]
+420justblazeit: checks 
+pokeher878787: checks 
+*** RIVER *** [6c 2c Ts 4c] [7s]
+420justblazeit: checks 
+pokeher878787: checks 
+*** SHOW DOWN ***
+420justblazeit: shows [As 4s] (a pair of Fours)
+pokeher878787: mucks hand 
+420justblazeit collected 614 from pot
+*** SUMMARY ***
+Total pot 650 | Rake 36 
+Board [6c 2c Ts 4c 7s]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 (button) mucked [5d Jc]
+Seat 5: scra88le56 (small blind) folded before Flop
+Seat 6: 420justblazeit (big blind) showed [As 4s] and won (614) with a pair of Fours
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211270615600: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:55:15 WET [2020/04/03 17:55:15 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (41769 in chips) 
+Seat 4: pokeher878787 (15988 in chips) 
+Seat 5: scra88le56 (26906 in chips) 
+Seat 6: 420justblazeit (22089 in chips) 
+Seat 8: winghymliu (10000 in chips) 
+Seat 9: no1beyondfan888 (44045 in chips) 
+420justblazeit: posts small blind 50
+winghymliu: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Qs 5d]
+no1beyondfan888: raises 100 to 200
+hellokwanny: folds 
+pokeher878787: calls 200
+scra88le56: calls 200
+420justblazeit: folds 
+winghymliu: calls 100
+*** FLOP *** [8c Kc Jd]
+winghymliu: bets 1100
+no1beyondfan888: folds 
+pokeher878787: folds 
+scra88le56: calls 1100
+*** TURN *** [8c Kc Jd] [2c]
+winghymliu: bets 4200
+scra88le56: calls 4200
+*** RIVER *** [8c Kc Jd 2c] [6s]
+winghymliu: bets 4500 and is all-in
+scra88le56: folds 
+Uncalled bet (4500) returned to winghymliu
+winghymliu collected 10820 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 11450 | Rake 630 
+Board [8c Kc Jd 2c 6s]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 folded on the Flop
+Seat 5: scra88le56 (button) folded on the River
+Seat 6: 420justblazeit (small blind) folded before Flop
+Seat 8: winghymliu (big blind) collected (10820)
+Seat 9: no1beyondfan888 folded on the Flop
+
+
+
+PokerStars Home Game Hand #211270675372: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:56:18 WET [2020/04/03 17:56:18 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (41769 in chips) 
+Seat 4: pokeher878787 (15788 in chips) 
+Seat 5: scra88le56 (21406 in chips) 
+Seat 6: 420justblazeit (22039 in chips) 
+Seat 8: winghymliu (15320 in chips) 
+Seat 9: no1beyondfan888 (43845 in chips) 
+winghymliu: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [3h 7c]
+hellokwanny: folds 
+pokeher878787: raises 200 to 300
+scra88le56: raises 200 to 500
+420justblazeit: folds 
+winghymliu: folds 
+no1beyondfan888: calls 400
+pokeher878787: raises 200 to 700
+scra88le56: raises 700 to 1400
+no1beyondfan888: calls 900
+pokeher878787: calls 700
+*** FLOP *** [7h 6d 5c]
+no1beyondfan888: checks 
+pokeher878787: bets 100
+scra88le56: raises 8300 to 8400
+no1beyondfan888: folds 
+pokeher878787: folds 
+Uncalled bet (8300) returned to scra88le56
+scra88le56 collected 4205 from pot
+scra88le56: doesn't show hand 
+*** SUMMARY ***
+Total pot 4450 | Rake 245 
+Board [7h 6d 5c]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 folded on the Flop
+Seat 5: scra88le56 collected (4205)
+Seat 6: 420justblazeit (button) folded before Flop (didn't bet)
+Seat 8: winghymliu (small blind) folded before Flop
+Seat 9: no1beyondfan888 (big blind) folded on the Flop
+
+
+
+PokerStars Home Game Hand #211270728416: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:57:14 WET [2020/04/03 17:57:14 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (41769 in chips) 
+Seat 4: pokeher878787 (14288 in chips) 
+Seat 5: scra88le56 (24111 in chips) 
+Seat 6: 420justblazeit (22039 in chips) 
+Seat 8: winghymliu (15270 in chips) 
+Seat 9: no1beyondfan888 (42445 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Jh 5s]
+pokeher878787: raises 200 to 300
+scra88le56: folds 
+420justblazeit: calls 300
+winghymliu: calls 300
+no1beyondfan888: calls 250
+hellokwanny: folds 
+*** FLOP *** [7s 3h 9s]
+no1beyondfan888: checks 
+pokeher878787: bets 614
+420justblazeit: folds 
+winghymliu: raises 2456 to 3070
+no1beyondfan888: folds 
+pokeher878787: folds 
+Uncalled bet (2456) returned to winghymliu
+winghymliu collected 2389 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 2528 | Rake 139 
+Board [7s 3h 9s]
+Seat 1: hellokwanny (big blind) folded before Flop
+Seat 4: pokeher878787 folded on the Flop
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit folded on the Flop
+Seat 8: winghymliu (button) collected (2389)
+Seat 9: no1beyondfan888 (small blind) folded on the Flop
+
+
+
+PokerStars Home Game Hand #211270783838: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:58:11 WET [2020/04/03 17:58:11 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (41669 in chips) 
+Seat 4: pokeher878787 (13374 in chips) 
+Seat 5: scra88le56 (24111 in chips) 
+Seat 6: 420justblazeit (21739 in chips) 
+Seat 8: winghymliu (16745 in chips) 
+Seat 9: no1beyondfan888 (42145 in chips) 
+hellokwanny: posts small blind 50
+pokeher878787: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Jd 9s]
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: calls 100
+no1beyondfan888: folds 
+hellokwanny: calls 50
+pokeher878787: raises 200 to 300
+winghymliu: calls 200
+hellokwanny: calls 200
+*** FLOP *** [Kc 3s 7h]
+hellokwanny: checks 
+pokeher878787: bets 425
+winghymliu: folds 
+hellokwanny: folds 
+Uncalled bet (425) returned to pokeher878787
+pokeher878787 collected 850 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 900 | Rake 50 
+Board [Kc 3s 7h]
+Seat 1: hellokwanny (small blind) folded on the Flop
+Seat 4: pokeher878787 (big blind) collected (850)
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu folded on the Flop
+Seat 9: no1beyondfan888 (button) folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211270829692: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:58:58 WET [2020/04/03 17:58:58 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (41369 in chips) 
+Seat 4: pokeher878787 (13924 in chips) 
+Seat 5: scra88le56 (24111 in chips) 
+Seat 6: 420justblazeit (21739 in chips) 
+Seat 8: winghymliu (16445 in chips) 
+pokeher878787: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [4c Qs]
+420justblazeit: folds 
+winghymliu: calls 100
+hellokwanny: folds 
+pokeher878787: calls 50
+scra88le56: checks 
+*** FLOP *** [3s Jc 8c]
+pokeher878787: checks 
+scra88le56: checks 
+winghymliu: checks 
+*** TURN *** [3s Jc 8c] [8s]
+pokeher878787: bets 100
+scra88le56: folds 
+winghymliu: calls 100
+*** RIVER *** [3s Jc 8c 8s] [8h]
+pokeher878787: bets 200
+winghymliu: calls 200
+*** SHOW DOWN ***
+pokeher878787: shows [4h 9s] (three of a kind, Eights)
+winghymliu: shows [3h 2c] (a full house, Eights full of Threes)
+winghymliu collected 850 from pot
+*** SUMMARY ***
+Total pot 900 | Rake 50 
+Board [3s Jc 8c 8s 8h]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 4: pokeher878787 (small blind) showed [4h 9s] and lost with three of a kind, Eights
+Seat 5: scra88le56 (big blind) folded on the Turn
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu showed [3h 2c] and won (850) with a full house, Eights full of Threes
+
+
+
+PokerStars Home Game Hand #211270881332: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 22:59:50 WET [2020/04/03 17:59:50 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #4 is the button
+Seat 1: hellokwanny (41369 in chips) 
+Seat 4: pokeher878787 (13524 in chips) 
+Seat 5: scra88le56 (24011 in chips) 
+Seat 6: 420justblazeit (21739 in chips) 
+Seat 8: winghymliu (16895 in chips) 
+Seat 9: no1beyondfan888 (42145 in chips) 
+scra88le56: posts small blind 50
+420justblazeit: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [5s Qs]
+winghymliu: raises 100 to 200
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: calls 200
+scra88le56: folds 
+420justblazeit: calls 100
+*** FLOP *** [7h 5h 3d]
+420justblazeit: checks 
+winghymliu: checks 
+pokeher878787: bets 307
+420justblazeit: folds 
+winghymliu: folds 
+Uncalled bet (307) returned to pokeher878787
+pokeher878787 collected 614 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 650 | Rake 36 
+Board [7h 5h 3d]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 (button) collected (614)
+Seat 5: scra88le56 (small blind) folded before Flop
+Seat 6: 420justblazeit (big blind) folded on the Flop
+Seat 8: winghymliu folded on the Flop
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211270938002: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:00:42 WET [2020/04/03 18:00:42 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (41369 in chips) 
+Seat 4: pokeher878787 (13938 in chips) 
+Seat 5: scra88le56 (23961 in chips) 
+Seat 6: 420justblazeit (21539 in chips) 
+Seat 8: winghymliu (16695 in chips) 
+Seat 9: no1beyondfan888 (42145 in chips) 
+420justblazeit: posts small blind 50
+winghymliu: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Th 7h]
+no1beyondfan888: calls 100
+hellokwanny: folds 
+pokeher878787: calls 100
+scra88le56: raises 700 to 800
+420justblazeit: folds 
+winghymliu: folds 
+no1beyondfan888: folds 
+pokeher878787: folds 
+Uncalled bet (700) returned to scra88le56
+scra88le56 collected 450 from pot
+scra88le56: doesn't show hand 
+*** SUMMARY ***
+Total pot 450 | Rake 0 
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 folded before Flop
+Seat 5: scra88le56 (button) collected (450)
+Seat 6: 420justblazeit (small blind) folded before Flop
+Seat 8: winghymliu (big blind) folded before Flop
+Seat 9: no1beyondfan888 folded before Flop
+
+
+
+PokerStars Home Game Hand #211271005199: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:01:23 WET [2020/04/03 18:01:23 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (41369 in chips) 
+Seat 4: pokeher878787 (13838 in chips) 
+Seat 5: scra88le56 (24311 in chips) 
+Seat 6: 420justblazeit (21489 in chips) 
+Seat 8: winghymliu (16595 in chips) 
+Seat 9: no1beyondfan888 (42045 in chips) 
+winghymliu: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [4h Qs]
+hellokwanny: folds 
+pokeher878787: calls 100
+scra88le56: calls 100
+420justblazeit: folds 
+winghymliu: calls 50
+no1beyondfan888: checks 
+*** FLOP *** [Kc 3s 2s]
+winghymliu: checks 
+no1beyondfan888: checks 
+pokeher878787: bets 189
+scra88le56: folds 
+winghymliu: folds 
+no1beyondfan888: folds 
+Uncalled bet (189) returned to pokeher878787
+pokeher878787 collected 378 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 400 | Rake 22 
+Board [Kc 3s 2s]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 collected (378)
+Seat 5: scra88le56 folded on the Flop
+Seat 6: 420justblazeit (button) folded before Flop (didn't bet)
+Seat 8: winghymliu (small blind) folded on the Flop
+Seat 9: no1beyondfan888 (big blind) folded on the Flop
+
+
+
+PokerStars Home Game Hand #211271052759: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:02:01 WET [2020/04/03 18:02:01 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (41369 in chips) 
+Seat 4: pokeher878787 (14116 in chips) 
+Seat 5: scra88le56 (24211 in chips) 
+Seat 6: 420justblazeit (21489 in chips) 
+Seat 8: winghymliu (16495 in chips) 
+Seat 9: no1beyondfan888 (41945 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Ts 9d]
+pokeher878787: calls 100
+scra88le56: calls 100
+420justblazeit: folds 
+winghymliu: calls 100
+no1beyondfan888: folds 
+hellokwanny: checks 
+*** FLOP *** [As Ac 4h]
+hellokwanny: checks 
+pokeher878787: bets 100
+scra88le56: calls 100
+winghymliu: calls 100
+hellokwanny: folds 
+*** TURN *** [As Ac 4h] [8h]
+pokeher878787: bets 100
+scra88le56: calls 100
+winghymliu: calls 100
+*** RIVER *** [As Ac 4h 8h] [Kh]
+pokeher878787: bets 992
+scra88le56: folds 
+winghymliu: folds 
+Uncalled bet (992) returned to pokeher878787
+pokeher878787 collected 992 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 1050 | Rake 58 
+Board [As Ac 4h 8h Kh]
+Seat 1: hellokwanny (big blind) folded on the Flop
+Seat 4: pokeher878787 collected (992)
+Seat 5: scra88le56 folded on the River
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu (button) folded on the River
+Seat 9: no1beyondfan888 (small blind) folded before Flop
+
+
+
+PokerStars Home Game Hand #211271126020: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:02:56 WET [2020/04/03 18:02:56 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (41269 in chips) 
+Seat 4: pokeher878787 (14808 in chips) 
+Seat 5: scra88le56 (23911 in chips) 
+Seat 6: 420justblazeit (21489 in chips) 
+Seat 8: winghymliu (16195 in chips) 
+Seat 9: no1beyondfan888 (41895 in chips) 
+hellokwanny: posts small blind 50
+pokeher878787: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Js 4h]
+scra88le56: folds 
+420justblazeit: calls 100
+winghymliu: calls 100
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: raises 100 to 200
+420justblazeit: calls 100
+winghymliu: calls 100
+*** FLOP *** [Qc Th Jd]
+pokeher878787: bets 307
+420justblazeit: calls 307
+winghymliu: calls 307
+*** TURN *** [Qc Th Jd] [2s]
+pokeher878787: checks 
+420justblazeit: bets 400
+winghymliu: raises 1142 to 1542
+pokeher878787: folds 
+420justblazeit: folds 
+Uncalled bet (1142) returned to winghymliu
+winghymliu collected 2241 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 2371 | Rake 130 
+Board [Qc Th Jd 2s]
+Seat 1: hellokwanny (small blind) folded before Flop
+Seat 4: pokeher878787 (big blind) folded on the Turn
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit folded on the Turn
+Seat 8: winghymliu collected (2241)
+Seat 9: no1beyondfan888 (button) folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211271232730: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:04:16 WET [2020/04/03 18:04:16 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (41219 in chips) 
+Seat 4: pokeher878787 (14301 in chips) 
+Seat 5: scra88le56 (23911 in chips) 
+Seat 6: 420justblazeit (20582 in chips) 
+Seat 8: winghymliu (17529 in chips) 
+Seat 9: no1beyondfan888 (41895 in chips) 
+pokeher878787: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [5d 9h]
+420justblazeit: folds 
+winghymliu: folds 
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: calls 50
+scra88le56: checks 
+*** FLOP *** [Qc Ts Js]
+pokeher878787: checks 
+scra88le56: checks 
+*** TURN *** [Qc Ts Js] [Jc]
+pokeher878787: checks 
+scra88le56: bets 100
+pokeher878787: folds 
+Uncalled bet (100) returned to scra88le56
+scra88le56 collected 189 from pot
+scra88le56: doesn't show hand 
+*** SUMMARY ***
+Total pot 200 | Rake 11 
+Board [Qc Ts Js Jc]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 4: pokeher878787 (small blind) folded on the Turn
+Seat 5: scra88le56 (big blind) collected (189)
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211271275955: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:04:49 WET [2020/04/03 18:04:49 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #4 is the button
+Seat 1: hellokwanny (41219 in chips) 
+Seat 4: pokeher878787 (14201 in chips) 
+Seat 5: scra88le56 (24000 in chips) 
+Seat 6: 420justblazeit (20582 in chips) 
+Seat 8: winghymliu (17529 in chips) 
+Seat 9: no1beyondfan888 (41895 in chips) 
+scra88le56: posts small blind 50
+420justblazeit: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [2c 6s]
+winghymliu: folds 
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: calls 100
+scra88le56: folds 
+420justblazeit: checks 
+*** FLOP *** [3h Ac 5s]
+420justblazeit: checks 
+pokeher878787: bets 118
+420justblazeit: calls 118
+*** TURN *** [3h Ac 5s] [Qc]
+420justblazeit: checks 
+pokeher878787: bets 229
+420justblazeit: calls 229
+*** RIVER *** [3h Ac 5s Qc] [Jd]
+420justblazeit: checks 
+pokeher878787: checks 
+*** SHOW DOWN ***
+420justblazeit: shows [4s Ts] (high card Ace)
+pokeher878787: mucks hand 
+420justblazeit collected 892 from pot
+*** SUMMARY ***
+Total pot 944 | Rake 52 
+Board [3h Ac 5s Qc Jd]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 (button) mucked [9d 2d]
+Seat 5: scra88le56 (small blind) folded before Flop
+Seat 6: 420justblazeit (big blind) showed [4s Ts] and won (892) with high card Ace
+Seat 8: winghymliu folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211271332605: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:05:32 WET [2020/04/03 18:05:32 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (41219 in chips) 
+Seat 4: pokeher878787 (13754 in chips) 
+Seat 5: scra88le56 (23950 in chips) 
+Seat 6: 420justblazeit (21027 in chips) 
+Seat 8: winghymliu (17529 in chips) 
+Seat 9: no1beyondfan888 (41895 in chips) 
+420justblazeit: posts small blind 50
+winghymliu: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [2d 5d]
+no1beyondfan888: raises 100 to 200
+hellokwanny: folds 
+pokeher878787: calls 200
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: calls 100
+*** FLOP *** [8h Qh 5s]
+winghymliu: checks 
+no1beyondfan888: bets 307
+pokeher878787: folds 
+winghymliu: folds 
+Uncalled bet (307) returned to no1beyondfan888
+no1beyondfan888 collected 614 from pot
+no1beyondfan888: doesn't show hand 
+*** SUMMARY ***
+Total pot 650 | Rake 36 
+Board [8h Qh 5s]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 folded on the Flop
+Seat 5: scra88le56 (button) folded before Flop (didn't bet)
+Seat 6: 420justblazeit (small blind) folded before Flop
+Seat 8: winghymliu (big blind) folded on the Flop
+Seat 9: no1beyondfan888 collected (614)
+
+
+
+PokerStars Home Game Hand #211271382007: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:06:10 WET [2020/04/03 18:06:10 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (41219 in chips) 
+Seat 4: pokeher878787 (13554 in chips) 
+Seat 5: scra88le56 (23950 in chips) 
+Seat 6: 420justblazeit (20977 in chips) 
+Seat 8: winghymliu (17329 in chips) 
+Seat 9: no1beyondfan888 (42309 in chips) 
+winghymliu: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [6s 8h]
+hellokwanny: folds 
+pokeher878787: raises 200 to 300
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: folds 
+no1beyondfan888: raises 200 to 500
+pokeher878787: raises 200 to 700
+no1beyondfan888: raises 200 to 900
+pokeher878787: raises 200 to 1100
+no1beyondfan888: raises 200 to 1300
+pokeher878787: raises 200 to 1500
+no1beyondfan888: calls 200
+*** FLOP *** [3c As 8d]
+no1beyondfan888: checks 
+pokeher878787: bets 1441
+no1beyondfan888: calls 1441
+*** TURN *** [3c As 8d] [5d]
+no1beyondfan888: bets 39368 and is all-in
+pokeher878787: folds 
+Uncalled bet (39368) returned to no1beyondfan888
+no1beyondfan888 collected 5606 from pot
+no1beyondfan888: doesn't show hand 
+*** SUMMARY ***
+Total pot 5932 | Rake 326 
+Board [3c As 8d 5d]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 folded on the Turn
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit (button) folded before Flop (didn't bet)
+Seat 8: winghymliu (small blind) folded before Flop
+Seat 9: no1beyondfan888 (big blind) collected (5606)
+
+
+
+PokerStars Home Game Hand #211271448177: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:07:01 WET [2020/04/03 18:07:01 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (41219 in chips) 
+Seat 4: pokeher878787 (10613 in chips) 
+Seat 5: scra88le56 (23950 in chips) 
+Seat 6: 420justblazeit (20977 in chips) 
+Seat 8: winghymliu (17279 in chips) 
+Seat 9: no1beyondfan888 (44974 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [4d Kh]
+pokeher878787: folds 
+scra88le56: calls 100
+420justblazeit: folds 
+winghymliu: raises 100 to 200
+no1beyondfan888: calls 150
+hellokwanny: folds 
+scra88le56: calls 100
+*** FLOP *** [2c Td Ad]
+no1beyondfan888: bets 100
+scra88le56: raises 100 to 200
+winghymliu: raises 1161 to 1361
+no1beyondfan888: folds 
+scra88le56: calls 1161
+*** TURN *** [2c Td Ad] [9s]
+scra88le56: checks 
+winghymliu: bets 3328
+scra88le56: folds 
+Uncalled bet (3328) returned to winghymliu
+winghymliu collected 3328 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 3522 | Rake 194 
+Board [2c Td Ad 9s]
+Seat 1: hellokwanny (big blind) folded before Flop
+Seat 4: pokeher878787 folded before Flop (didn't bet)
+Seat 5: scra88le56 folded on the Turn
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu (button) collected (3328)
+Seat 9: no1beyondfan888 (small blind) folded on the Flop
+
+
+
+PokerStars Home Game Hand #211271517806: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:07:55 WET [2020/04/03 18:07:55 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (41119 in chips) 
+Seat 4: pokeher878787 (10613 in chips) 
+Seat 5: scra88le56 (22389 in chips) 
+Seat 6: 420justblazeit (20977 in chips) 
+Seat 8: winghymliu (19046 in chips) 
+Seat 9: no1beyondfan888 (44674 in chips) 
+hellokwanny: posts small blind 50
+pokeher878787: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Qd 6c]
+scra88le56: calls 100
+420justblazeit: folds 
+winghymliu: raises 350 to 450
+no1beyondfan888: calls 450
+hellokwanny: folds 
+pokeher878787: folds 
+scra88le56: calls 350
+*** FLOP *** [3d 6s Ts]
+scra88le56: checks 
+winghymliu: bets 1417
+no1beyondfan888: calls 1417
+scra88le56: folds 
+*** TURN *** [3d 6s Ts] [2s]
+winghymliu: bets 4096
+no1beyondfan888: calls 4096
+*** RIVER *** [3d 6s Ts 2s] [Kc]
+winghymliu: checks 
+no1beyondfan888: bets 38711 and is all-in
+winghymliu has timed out
+winghymliu: folds 
+Uncalled bet (38711) returned to no1beyondfan888
+no1beyondfan888 collected 11837 from pot
+no1beyondfan888: doesn't show hand 
+*** SUMMARY ***
+Total pot 12526 | Rake 689 
+Board [3d 6s Ts 2s Kc]
+Seat 1: hellokwanny (small blind) folded before Flop
+Seat 4: pokeher878787 (big blind) folded before Flop
+Seat 5: scra88le56 folded on the Flop
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu folded on the River
+Seat 9: no1beyondfan888 (button) collected (11837)
+
+
+
+PokerStars Home Game Hand #211271594245: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:08:54 WET [2020/04/03 18:08:54 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (41069 in chips) 
+Seat 4: pokeher878787 (10513 in chips) 
+Seat 5: scra88le56 (21939 in chips) 
+Seat 6: 420justblazeit (20977 in chips) 
+Seat 9: no1beyondfan888 (50548 in chips) 
+pokeher878787: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Jd 6h]
+420justblazeit: raises 200 to 300
+no1beyondfan888: calls 300
+hellokwanny: folds 
+pokeher878787: folds 
+scra88le56: calls 200
+*** FLOP *** [Jh 8h 2h]
+scra88le56: bets 100
+420justblazeit: raises 549 to 649
+no1beyondfan888: folds 
+scra88le56: folds 
+Uncalled bet (549) returned to 420justblazeit
+420justblazeit collected 1087 from pot
+420justblazeit: doesn't show hand 
+*** SUMMARY ***
+Total pot 1150 | Rake 63 
+Board [Jh 8h 2h]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 4: pokeher878787 (small blind) folded before Flop
+Seat 5: scra88le56 (big blind) folded on the Flop
+Seat 6: 420justblazeit collected (1087)
+Seat 9: no1beyondfan888 folded on the Flop
+
+
+
+PokerStars Home Game Hand #211271646515: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:09:35 WET [2020/04/03 18:09:35 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #4 is the button
+Seat 1: hellokwanny (41069 in chips) 
+Seat 4: pokeher878787 (10463 in chips) 
+Seat 5: scra88le56 (21539 in chips) 
+Seat 6: 420justblazeit (21664 in chips) 
+Seat 8: winghymliu (13083 in chips) 
+Seat 9: no1beyondfan888 (50248 in chips) 
+scra88le56: posts small blind 50
+420justblazeit: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Ts Td]
+winghymliu: calls 100
+no1beyondfan888: calls 100
+hellokwanny: raises 400 to 500
+pokeher878787: folds 
+scra88le56: calls 450
+420justblazeit: folds 
+winghymliu: calls 400
+no1beyondfan888: calls 400
+*** FLOP *** [Tc 5s 3c]
+scra88le56: bets 2500
+winghymliu: folds 
+no1beyondfan888: folds 
+hellokwanny: raises 3500 to 6000
+scra88le56: calls 3500
+*** TURN *** [Tc 5s 3c] [7d]
+scra88le56: checks 
+hellokwanny: bets 14900
+scra88le56: folds 
+Uncalled bet (14900) returned to hellokwanny
+hellokwanny collected 13324 from pot
+hellokwanny: doesn't show hand 
+*** SUMMARY ***
+Total pot 14100 | Rake 776 
+Board [Tc 5s 3c 7d]
+Seat 1: hellokwanny collected (13324)
+Seat 4: pokeher878787 (button) folded before Flop (didn't bet)
+Seat 5: scra88le56 (small blind) folded on the Turn
+Seat 6: 420justblazeit (big blind) folded before Flop
+Seat 8: winghymliu folded on the Flop
+Seat 9: no1beyondfan888 folded on the Flop
+
+
+
+PokerStars Home Game Hand #211271729537: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:10:40 WET [2020/04/03 18:10:40 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (47893 in chips) 
+Seat 4: pokeher878787 (10463 in chips) 
+Seat 5: scra88le56 (15039 in chips) 
+Seat 6: 420justblazeit (21564 in chips) 
+Seat 8: winghymliu (12583 in chips) 
+Seat 9: no1beyondfan888 (49748 in chips) 
+420justblazeit: posts small blind 50
+winghymliu: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Qs 2c]
+no1beyondfan888: calls 100
+hellokwanny: folds 
+pokeher878787: raises 200 to 300
+scra88le56: calls 300
+420justblazeit: folds 
+winghymliu: raises 700 to 1000
+no1beyondfan888: folds 
+pokeher878787: raises 700 to 1700
+scra88le56: folds 
+winghymliu: raises 1100 to 2800
+pokeher878787: raises 1100 to 3900
+winghymliu: raises 1100 to 5000
+pokeher878787: raises 5463 to 10463 and is all-in
+winghymliu: calls 5463
+*** FLOP *** [7d Jh 8d]
+*** TURN *** [7d Jh 8d] [Qh]
+*** RIVER *** [7d Jh 8d Qh] [5c]
+*** SHOW DOWN ***
+winghymliu: shows [Ah Ad] (a pair of Aces)
+pokeher878787: shows [Kd Kh] (a pair of Kings)
+winghymliu collected 20200 from pot
+*** SUMMARY ***
+Total pot 21376 | Rake 1176 
+Board [7d Jh 8d Qh 5c]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 showed [Kd Kh] and lost with a pair of Kings
+Seat 5: scra88le56 (button) folded before Flop
+Seat 6: 420justblazeit (small blind) folded before Flop
+Seat 8: winghymliu (big blind) showed [Ah Ad] and won (20200) with a pair of Aces
+Seat 9: no1beyondfan888 folded before Flop
+
+
+
+PokerStars Home Game Hand #211271792949: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:11:29 WET [2020/04/03 18:11:29 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (47893 in chips) 
+Seat 5: scra88le56 (14739 in chips) 
+Seat 6: 420justblazeit (21514 in chips) 
+Seat 8: winghymliu (22320 in chips) 
+Seat 9: no1beyondfan888 (49648 in chips) 
+winghymliu: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Th Js]
+hellokwanny: raises 200 to 300
+scra88le56: calls 300
+420justblazeit: folds 
+winghymliu: folds 
+no1beyondfan888: calls 200
+*** FLOP *** [4d 9s Ah]
+no1beyondfan888: checks 
+hellokwanny: checks 
+scra88le56: checks 
+*** TURN *** [4d 9s Ah] [As]
+no1beyondfan888: checks 
+hellokwanny: checks 
+scra88le56: bets 449
+no1beyondfan888: calls 449
+hellokwanny: folds 
+*** RIVER *** [4d 9s Ah As] [Jd]
+no1beyondfan888: checks 
+scra88le56: bets 873
+no1beyondfan888: calls 873
+*** SHOW DOWN ***
+scra88le56: shows [5s Ks] (a pair of Aces)
+no1beyondfan888: mucks hand 
+scra88le56 collected 3396 from pot
+*** SUMMARY ***
+Total pot 3594 | Rake 198 
+Board [4d 9s Ah As Jd]
+Seat 1: hellokwanny folded on the Turn
+Seat 5: scra88le56 showed [5s Ks] and won (3396) with a pair of Aces
+Seat 6: 420justblazeit (button) folded before Flop (didn't bet)
+Seat 8: winghymliu (small blind) folded before Flop
+Seat 9: no1beyondfan888 (big blind) mucked [Ts 7s]
+
+
+
+PokerStars Home Game Hand #211271861074: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:12:19 WET [2020/04/03 18:12:19 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (47593 in chips) 
+Seat 5: scra88le56 (16513 in chips) 
+Seat 6: 420justblazeit (21514 in chips) 
+Seat 8: winghymliu (22270 in chips) 
+Seat 9: no1beyondfan888 (48026 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Ah Jd]
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: raises 100 to 200
+no1beyondfan888: calls 150
+hellokwanny: raises 300 to 500
+winghymliu: calls 300
+no1beyondfan888: calls 300
+*** FLOP *** [9h 5d 8s]
+no1beyondfan888: checks 
+hellokwanny: bets 708
+winghymliu: raises 1416 to 2124
+no1beyondfan888: folds 
+hellokwanny: folds 
+Uncalled bet (1416) returned to winghymliu
+winghymliu collected 2756 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 2916 | Rake 160 
+Board [9h 5d 8s]
+Seat 1: hellokwanny (big blind) folded on the Flop
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu (button) collected (2756)
+Seat 9: no1beyondfan888 (small blind) folded on the Flop
+
+
+
+PokerStars Home Game Hand #211271934847: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:13:16 WET [2020/04/03 18:13:16 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (46385 in chips) 
+Seat 5: scra88le56 (16513 in chips) 
+Seat 6: 420justblazeit (21514 in chips) 
+Seat 8: winghymliu (23818 in chips) 
+Seat 9: no1beyondfan888 (47526 in chips) 
+hellokwanny: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [8d 8c]
+420justblazeit: folds 
+winghymliu: folds 
+no1beyondfan888: folds 
+hellokwanny: raises 100 to 200
+scra88le56: raises 500 to 700
+hellokwanny: calls 500
+*** FLOP *** [8h 5h Tc]
+hellokwanny: checks 
+scra88le56: bets 500
+hellokwanny: raises 700 to 1200
+scra88le56: calls 700
+*** TURN *** [8h 5h Tc] [Qd]
+hellokwanny: bets 1795
+scra88le56: calls 1795
+*** RIVER *** [8h 5h Tc Qd] [Ah]
+hellokwanny: bets 3492
+scra88le56: raises 9326 to 12818 and is all-in
+hellokwanny: calls 9326
+*** SHOW DOWN ***
+scra88le56: shows [Js Ks] (a straight, Ten to Ace)
+hellokwanny: shows [8d 8c] (three of a kind, Eights)
+scra88le56 collected 31210 from pot
+*** SUMMARY ***
+Total pot 33026 | Rake 1816 
+Board [8h 5h Tc Qd Ah]
+Seat 1: hellokwanny (small blind) showed [8d 8c] and lost with three of a kind, Eights
+Seat 5: scra88le56 (big blind) showed [Js Ks] and won (31210) with a straight, Ten to Ace
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 (button) folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211272008977: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:14:15 WET [2020/04/03 18:14:15 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (29872 in chips) 
+Seat 5: scra88le56 (31210 in chips) 
+Seat 6: 420justblazeit (21514 in chips) 
+Seat 8: winghymliu (23818 in chips) 
+Seat 9: no1beyondfan888 (47526 in chips) 
+scra88le56: posts small blind 50
+420justblazeit: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [2h Th]
+winghymliu: raises 100 to 200
+no1beyondfan888: folds 
+hellokwanny: folds 
+scra88le56: folds 
+420justblazeit: calls 100
+*** FLOP *** [Ah 5h Td]
+420justblazeit: checks 
+winghymliu: bets 425
+420justblazeit: folds 
+Uncalled bet (425) returned to winghymliu
+winghymliu collected 425 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 450 | Rake 25 
+Board [Ah 5h Td]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 5: scra88le56 (small blind) folded before Flop
+Seat 6: 420justblazeit (big blind) folded on the Flop
+Seat 8: winghymliu collected (425)
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211272049978: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:14:47 WET [2020/04/03 18:14:47 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (29872 in chips) 
+Seat 4: pokeher878787 (10000 in chips) 
+Seat 5: scra88le56 (31160 in chips) 
+Seat 6: 420justblazeit (21314 in chips) 
+Seat 8: winghymliu (24043 in chips) 
+Seat 9: no1beyondfan888 (47526 in chips) 
+420justblazeit: posts small blind 50
+winghymliu: posts big blind 100
+pokeher878787: posts small & big blinds 150
+*** HOLE CARDS ***
+Dealt to hellokwanny [5s Jh]
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: checks 
+scra88le56: folds 
+420justblazeit: calls 50
+winghymliu: checks 
+*** FLOP *** [5d 4c 8d]
+420justblazeit: checks 
+winghymliu: checks 
+pokeher878787: checks 
+*** TURN *** [5d 4c 8d] [6c]
+420justblazeit: checks 
+winghymliu: checks 
+pokeher878787: bets 165
+420justblazeit: calls 165
+winghymliu: calls 165
+*** RIVER *** [5d 4c 8d 6c] [9c]
+420justblazeit: checks 
+winghymliu: bets 100
+pokeher878787: calls 100
+420justblazeit: calls 100
+*** SHOW DOWN ***
+winghymliu: shows [3s 9s] (a pair of Nines)
+pokeher878787: mucks hand 
+420justblazeit: mucks hand 
+winghymliu collected 1082 from pot
+*** SUMMARY ***
+Total pot 1145 | Rake 63 
+Board [5d 4c 8d 6c 9c]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 mucked [2s 4h]
+Seat 5: scra88le56 (button) folded before Flop (didn't bet)
+Seat 6: 420justblazeit (small blind) mucked [Ad Th]
+Seat 8: winghymliu (big blind) showed [3s 9s] and won (1082) with a pair of Nines
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211272130211: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:15:50 WET [2020/04/03 18:15:50 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (29872 in chips) 
+Seat 4: pokeher878787 (9585 in chips) 
+Seat 5: scra88le56 (31160 in chips) 
+Seat 6: 420justblazeit (20949 in chips) 
+Seat 8: winghymliu (24760 in chips) 
+Seat 9: no1beyondfan888 (47526 in chips) 
+winghymliu: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [8d 6d]
+hellokwanny: raises 200 to 300
+pokeher878787: folds 
+scra88le56: calls 300
+420justblazeit: folds 
+winghymliu: folds 
+no1beyondfan888: calls 200
+*** FLOP *** [Kc Kd 8h]
+no1beyondfan888: checks 
+hellokwanny: checks 
+scra88le56: checks 
+*** TURN *** [Kc Kd 8h] [4d]
+no1beyondfan888: bets 449
+hellokwanny: calls 449
+scra88le56: calls 449
+*** RIVER *** [Kc Kd 8h 4d] [8s]
+no1beyondfan888: bets 2171
+hellokwanny: calls 2171
+scra88le56: folds 
+*** SHOW DOWN ***
+no1beyondfan888: shows [Ks 6c] (a full house, Kings full of Eights)
+hellokwanny: mucks hand 
+no1beyondfan888 collected 6274 from pot
+*** SUMMARY ***
+Total pot 6639 | Rake 365 
+Board [Kc Kd 8h 4d 8s]
+Seat 1: hellokwanny mucked [8d 6d]
+Seat 4: pokeher878787 folded before Flop (didn't bet)
+Seat 5: scra88le56 folded on the River
+Seat 6: 420justblazeit (button) folded before Flop (didn't bet)
+Seat 8: winghymliu (small blind) folded before Flop
+Seat 9: no1beyondfan888 (big blind) showed [Ks 6c] and won (6274) with a full house, Kings full of Eights
+
+
+
+PokerStars Home Game Hand #211272193671: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:16:40 WET [2020/04/03 18:16:40 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (26952 in chips) 
+Seat 4: pokeher878787 (9585 in chips) 
+Seat 5: scra88le56 (30411 in chips) 
+Seat 6: 420justblazeit (20949 in chips) 
+Seat 8: winghymliu (24710 in chips) 
+Seat 9: no1beyondfan888 (50880 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [3c 2d]
+pokeher878787: raises 200 to 300
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: calls 300
+no1beyondfan888: folds 
+hellokwanny: folds 
+*** FLOP *** [Th 6c Ah]
+pokeher878787: bets 354
+winghymliu: folds 
+Uncalled bet (354) returned to pokeher878787
+pokeher878787 collected 709 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 750 | Rake 41 
+Board [Th 6c Ah]
+Seat 1: hellokwanny (big blind) folded before Flop
+Seat 4: pokeher878787 collected (709)
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu (button) folded on the Flop
+Seat 9: no1beyondfan888 (small blind) folded before Flop
+
+
+
+PokerStars Home Game Hand #211272236829: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:17:14 WET [2020/04/03 18:17:14 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (26852 in chips) 
+Seat 4: pokeher878787 (9994 in chips) 
+Seat 5: scra88le56 (30411 in chips) 
+Seat 6: 420justblazeit (20949 in chips) 
+Seat 8: winghymliu (24410 in chips) 
+pokeher878787: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [3d 6s]
+420justblazeit: folds 
+winghymliu: folds 
+hellokwanny: folds 
+pokeher878787: raises 200 to 300
+scra88le56: folds 
+Uncalled bet (200) returned to pokeher878787
+pokeher878787 collected 200 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 200 | Rake 0 
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 4: pokeher878787 (small blind) collected (200)
+Seat 5: scra88le56 (big blind) folded before Flop
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211272261955: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:17:34 WET [2020/04/03 18:17:34 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #4 is the button
+Seat 1: hellokwanny (26852 in chips) 
+Seat 4: pokeher878787 (10094 in chips) 
+Seat 5: scra88le56 (30311 in chips) 
+Seat 6: 420justblazeit (20949 in chips) 
+Seat 8: winghymliu (24410 in chips) 
+scra88le56: posts small blind 50
+420justblazeit: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [2h 9s]
+winghymliu: folds 
+hellokwanny: folds 
+pokeher878787: raises 200 to 300
+scra88le56: folds 
+420justblazeit: folds 
+Uncalled bet (200) returned to pokeher878787
+pokeher878787 collected 250 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 250 | Rake 0 
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 (button) collected (250)
+Seat 5: scra88le56 (small blind) folded before Flop
+Seat 6: 420justblazeit (big blind) folded before Flop
+Seat 8: winghymliu folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211272282820: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:17:51 WET [2020/04/03 18:17:51 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (26852 in chips) 
+Seat 4: pokeher878787 (10244 in chips) 
+Seat 5: scra88le56 (30261 in chips) 
+Seat 6: 420justblazeit (20849 in chips) 
+Seat 8: winghymliu (24410 in chips) 
+420justblazeit: posts small blind 50
+winghymliu: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [8c Kc]
+hellokwanny: raises 200 to 300
+pokeher878787: calls 300
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: calls 200
+*** FLOP *** [9s Jh 4c]
+winghymliu: bets 898
+hellokwanny: folds 
+pokeher878787: folds 
+Uncalled bet (898) returned to winghymliu
+winghymliu collected 898 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 950 | Rake 52 
+Board [9s Jh 4c]
+Seat 1: hellokwanny folded on the Flop
+Seat 4: pokeher878787 folded on the Flop
+Seat 5: scra88le56 (button) folded before Flop (didn't bet)
+Seat 6: 420justblazeit (small blind) folded before Flop
+Seat 8: winghymliu (big blind) collected (898)
+
+
+
+PokerStars Home Game Hand #211272331477: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:18:29 WET [2020/04/03 18:18:29 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (26552 in chips) 
+Seat 4: pokeher878787 (9944 in chips) 
+Seat 5: scra88le56 (30261 in chips) 
+Seat 6: 420justblazeit (20799 in chips) 
+Seat 8: winghymliu (25008 in chips) 
+winghymliu: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Ad 2d]
+pokeher878787: calls 100
+scra88le56: calls 100
+420justblazeit: folds 
+winghymliu: calls 50
+hellokwanny: raises 200 to 300
+pokeher878787: calls 200
+scra88le56: calls 200
+winghymliu: calls 200
+*** FLOP *** [8h 4s 2c]
+winghymliu: checks 
+hellokwanny: checks 
+pokeher878787: checks 
+scra88le56: bets 567
+winghymliu: folds 
+hellokwanny: folds 
+pokeher878787: folds 
+Uncalled bet (567) returned to scra88le56
+scra88le56 collected 1134 from pot
+scra88le56: doesn't show hand 
+*** SUMMARY ***
+Total pot 1200 | Rake 66 
+Board [8h 4s 2c]
+Seat 1: hellokwanny (big blind) folded on the Flop
+Seat 4: pokeher878787 folded on the Flop
+Seat 5: scra88le56 collected (1134)
+Seat 6: 420justblazeit (button) folded before Flop (didn't bet)
+Seat 8: winghymliu (small blind) folded on the Flop
+
+
+
+PokerStars Home Game Hand #211272407379: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:19:26 WET [2020/04/03 18:19:26 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (26252 in chips) 
+Seat 4: pokeher878787 (9644 in chips) 
+Seat 5: scra88le56 (31095 in chips) 
+Seat 6: 420justblazeit (20799 in chips) 
+Seat 8: winghymliu (24708 in chips) 
+hellokwanny: posts small blind 50
+pokeher878787: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Jc 4s]
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: calls 100
+hellokwanny: folds 
+pokeher878787: checks 
+*** FLOP *** [9h Qd 8d]
+pokeher878787: checks 
+winghymliu: checks 
+*** TURN *** [9h Qd 8d] [4c]
+pokeher878787: bets 118
+winghymliu: calls 118
+*** RIVER *** [9h Qd 8d 4c] [4d]
+pokeher878787: bets 1000
+winghymliu: folds 
+Uncalled bet (1000) returned to pokeher878787
+pokeher878787 collected 459 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 486 | Rake 27 
+Board [9h Qd 8d 4c 4d]
+Seat 1: hellokwanny (small blind) folded before Flop
+Seat 4: pokeher878787 (big blind) collected (459)
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu (button) folded on the River
+
+
+
+PokerStars Home Game Hand #211272473428: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:20:19 WET [2020/04/03 18:20:19 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (26202 in chips) 
+Seat 4: pokeher878787 (9885 in chips) 
+Seat 5: scra88le56 (31095 in chips) 
+Seat 6: 420justblazeit (20799 in chips) 
+Seat 8: winghymliu (24490 in chips) 
+Seat 9: no1beyondfan888 (50830 in chips) 
+pokeher878787: posts small blind 50
+scra88le56: posts big blind 100
+no1beyondfan888: posts small & big blinds 150
+*** HOLE CARDS ***
+Dealt to hellokwanny [Qs 6c]
+420justblazeit: raises 300 to 400
+winghymliu: folds 
+no1beyondfan888: calls 300
+hellokwanny: folds 
+pokeher878787: raises 300 to 700
+scra88le56: folds 
+420justblazeit: calls 300
+no1beyondfan888: calls 300
+*** FLOP *** [7s 7d As]
+pokeher878787: bets 2126
+420justblazeit: folds 
+no1beyondfan888: folds 
+Uncalled bet (2126) returned to pokeher878787
+pokeher878787 collected 2126 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 2250 | Rake 124 
+Board [7s 7d As]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 4: pokeher878787 (small blind) collected (2126)
+Seat 5: scra88le56 (big blind) folded before Flop
+Seat 6: 420justblazeit folded on the Flop
+Seat 8: winghymliu folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 folded on the Flop
+
+
+
+PokerStars Home Game Hand #211272535836: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:21:09 WET [2020/04/03 18:21:09 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #4 is the button
+Seat 1: hellokwanny (26202 in chips) 
+Seat 4: pokeher878787 (11311 in chips) 
+Seat 5: scra88le56 (30995 in chips) 
+Seat 6: 420justblazeit (20099 in chips) 
+Seat 8: winghymliu (24490 in chips) 
+Seat 9: no1beyondfan888 (50080 in chips) 
+scra88le56: posts small blind 50
+420justblazeit: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Kd 2h]
+winghymliu: folds 
+no1beyondfan888: calls 100
+hellokwanny: folds 
+pokeher878787: calls 100
+scra88le56: calls 50
+420justblazeit: raises 200 to 300
+no1beyondfan888: raises 200 to 500
+pokeher878787: calls 400
+scra88le56: folds 
+420justblazeit: calls 200
+*** FLOP *** [4h 2c Th]
+420justblazeit: checks 
+no1beyondfan888: checks 
+pokeher878787: bets 100
+420justblazeit: calls 100
+no1beyondfan888: raises 100 to 200
+pokeher878787: calls 100
+420justblazeit: calls 100
+*** TURN *** [4h 2c Th] [6h]
+420justblazeit: checks 
+no1beyondfan888: bets 100
+pokeher878787: calls 100
+420justblazeit: calls 100
+*** RIVER *** [4h 2c Th 6h] [8s]
+420justblazeit: checks 
+no1beyondfan888: bets 2362
+pokeher878787: folds 
+420justblazeit: folds 
+Uncalled bet (2362) returned to no1beyondfan888
+no1beyondfan888 collected 2362 from pot
+no1beyondfan888: doesn't show hand 
+*** SUMMARY ***
+Total pot 2500 | Rake 138 
+Board [4h 2c Th 6h 8s]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 (button) folded on the River
+Seat 5: scra88le56 (small blind) folded before Flop
+Seat 6: 420justblazeit (big blind) folded on the River
+Seat 8: winghymliu folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 collected (2362)
+
+
+
+PokerStars Home Game Hand #211272627860: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:22:23 WET [2020/04/03 18:22:23 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (26202 in chips) 
+Seat 4: pokeher878787 (10511 in chips) 
+Seat 5: scra88le56 (30895 in chips) 
+Seat 6: 420justblazeit (19299 in chips) 
+Seat 8: winghymliu (24490 in chips) 
+Seat 9: no1beyondfan888 (51642 in chips) 
+420justblazeit: posts small blind 50
+winghymliu: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [4h 2d]
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: calls 100
+scra88le56: calls 100
+420justblazeit: calls 50
+winghymliu: raises 700 to 800
+pokeher878787: folds 
+scra88le56: calls 700
+420justblazeit: folds 
+*** FLOP *** [Kd Qc 3s]
+winghymliu: checks 
+scra88le56: bets 400
+winghymliu: calls 400
+*** TURN *** [Kd Qc 3s] [Qh]
+winghymliu: bets 2457
+scra88le56: folds 
+Uncalled bet (2457) returned to winghymliu
+winghymliu collected 2457 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 2600 | Rake 143 
+Board [Kd Qc 3s Qh]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 folded before Flop
+Seat 5: scra88le56 (button) folded on the Turn
+Seat 6: 420justblazeit (small blind) folded before Flop
+Seat 8: winghymliu (big blind) collected (2457)
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211272700868: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:23:22 WET [2020/04/03 18:23:22 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (26202 in chips) 
+Seat 4: pokeher878787 (10411 in chips) 
+Seat 5: scra88le56 (29695 in chips) 
+Seat 6: 420justblazeit (19199 in chips) 
+Seat 8: winghymliu (25747 in chips) 
+Seat 9: no1beyondfan888 (51642 in chips) 
+winghymliu: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Kh Kc]
+hellokwanny: raises 300 to 400
+pokeher878787: folds 
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: calls 350
+no1beyondfan888: folds 
+*** FLOP *** [Js 5s 3c]
+winghymliu: checks 
+hellokwanny: bets 425
+winghymliu: raises 425 to 850
+hellokwanny: raises 950 to 1800
+winghymliu: folds 
+Uncalled bet (950) returned to hellokwanny
+hellokwanny collected 2457 from pot
+hellokwanny: doesn't show hand 
+*** SUMMARY ***
+Total pot 2600 | Rake 143 
+Board [Js 5s 3c]
+Seat 1: hellokwanny collected (2457)
+Seat 4: pokeher878787 folded before Flop (didn't bet)
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit (button) folded before Flop (didn't bet)
+Seat 8: winghymliu (small blind) folded on the Flop
+Seat 9: no1beyondfan888 (big blind) folded before Flop
+
+
+
+PokerStars Home Game Hand #211272786144: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:24:32 WET [2020/04/03 18:24:32 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (27409 in chips) 
+Seat 4: pokeher878787 (10411 in chips) 
+Seat 5: scra88le56 (29695 in chips) 
+Seat 6: 420justblazeit (19199 in chips) 
+Seat 8: winghymliu (24497 in chips) 
+Seat 9: no1beyondfan888 (51542 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Kh 9s]
+pokeher878787: folds 
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: raises 100 to 200
+no1beyondfan888: folds 
+hellokwanny: calls 100
+*** FLOP *** [2d 4c 8s]
+hellokwanny: checks 
+winghymliu: bets 700
+hellokwanny: folds 
+Uncalled bet (700) returned to winghymliu
+winghymliu collected 425 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 450 | Rake 25 
+Board [2d 4c 8s]
+Seat 1: hellokwanny (big blind) folded on the Flop
+Seat 4: pokeher878787 folded before Flop (didn't bet)
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu (button) collected (425)
+Seat 9: no1beyondfan888 (small blind) folded before Flop
+
+
+
+PokerStars Home Game Hand #211272829791: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:25:07 WET [2020/04/03 18:25:07 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (27209 in chips) 
+Seat 4: pokeher878787 (10411 in chips) 
+Seat 5: scra88le56 (29695 in chips) 
+Seat 6: 420justblazeit (19199 in chips) 
+Seat 8: winghymliu (24722 in chips) 
+Seat 9: no1beyondfan888 (51492 in chips) 
+hellokwanny: posts small blind 50
+pokeher878787: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [2h 5s]
+scra88le56: raises 400 to 500
+420justblazeit: folds 
+winghymliu: folds 
+no1beyondfan888: calls 500
+hellokwanny: folds 
+pokeher878787: calls 400
+*** FLOP *** [5h Qd Kc]
+pokeher878787: bets 1465
+scra88le56: calls 1465
+no1beyondfan888: folds 
+*** TURN *** [5h Qd Kc] [Ah]
+pokeher878787: bets 100
+scra88le56: raises 4434 to 4534
+pokeher878787: folds 
+Uncalled bet (4434) returned to scra88le56
+scra88le56 collected 4423 from pot
+scra88le56: doesn't show hand 
+*** SUMMARY ***
+Total pot 4680 | Rake 257 
+Board [5h Qd Kc Ah]
+Seat 1: hellokwanny (small blind) folded before Flop
+Seat 4: pokeher878787 (big blind) folded on the Turn
+Seat 5: scra88le56 collected (4423)
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 (button) folded on the Flop
+
+
+
+PokerStars Home Game Hand #211272906809: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:26:09 WET [2020/04/03 18:26:09 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (27159 in chips) 
+Seat 4: pokeher878787 (8346 in chips) 
+Seat 5: scra88le56 (32053 in chips) 
+Seat 6: 420justblazeit (19199 in chips) 
+Seat 8: winghymliu (24722 in chips) 
+Seat 9: no1beyondfan888 (50992 in chips) 
+pokeher878787: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [9d 3h]
+420justblazeit: folds 
+winghymliu: calls 100
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: raises 200 to 300
+scra88le56: calls 200
+winghymliu: calls 200
+*** FLOP *** [4h Td Kc]
+pokeher878787: bets 850
+scra88le56: folds 
+winghymliu: folds 
+Uncalled bet (850) returned to pokeher878787
+pokeher878787 collected 850 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 900 | Rake 50 
+Board [4h Td Kc]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 4: pokeher878787 (small blind) collected (850)
+Seat 5: scra88le56 (big blind) folded on the Flop
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu folded on the Flop
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211272955465: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:26:49 WET [2020/04/03 18:26:49 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #4 is the button
+Seat 1: hellokwanny (27159 in chips) 
+Seat 4: pokeher878787 (8896 in chips) 
+Seat 5: scra88le56 (31753 in chips) 
+Seat 6: 420justblazeit (19199 in chips) 
+Seat 8: winghymliu (24422 in chips) 
+Seat 9: no1beyondfan888 (50992 in chips) 
+scra88le56: posts small blind 50
+420justblazeit: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [9h Ks]
+winghymliu: raises 700 to 800
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: folds 
+scra88le56: folds 
+420justblazeit: calls 700
+*** FLOP *** [9d 7s Kc]
+420justblazeit: checks 
+winghymliu: bets 1900
+420justblazeit: folds 
+Uncalled bet (1900) returned to winghymliu
+winghymliu collected 1559 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 1650 | Rake 91 
+Board [9d 7s Kc]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 (button) folded before Flop (didn't bet)
+Seat 5: scra88le56 (small blind) folded before Flop
+Seat 6: 420justblazeit (big blind) folded on the Flop
+Seat 8: winghymliu collected (1559)
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211273028316: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:27:45 WET [2020/04/03 18:27:45 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (27159 in chips) 
+Seat 4: pokeher878787 (8896 in chips) 
+Seat 5: scra88le56 (31703 in chips) 
+Seat 6: 420justblazeit (18399 in chips) 
+Seat 8: winghymliu (25181 in chips) 
+Seat 9: no1beyondfan888 (50992 in chips) 
+420justblazeit: posts small blind 50
+winghymliu: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [6d 7c]
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: raises 200 to 300
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: calls 200
+*** FLOP *** [7h 4d Jd]
+winghymliu: checks 
+pokeher878787: bets 307
+winghymliu: calls 307
+*** TURN *** [7h 4d Jd] [8s]
+winghymliu: bets 2100
+pokeher878787: raises 6189 to 8289 and is all-in
+winghymliu has timed out
+winghymliu: folds 
+Uncalled bet (6189) returned to pokeher878787
+pokeher878787 collected 5163 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 5464 | Rake 301 
+Board [7h 4d Jd 8s]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 collected (5163)
+Seat 5: scra88le56 (button) folded before Flop (didn't bet)
+Seat 6: 420justblazeit (small blind) folded before Flop
+Seat 8: winghymliu (big blind) folded on the Turn
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211273111379: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:28:53 WET [2020/04/03 18:28:53 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (27159 in chips) 
+Seat 4: pokeher878787 (11352 in chips) 
+Seat 5: scra88le56 (31703 in chips) 
+Seat 6: 420justblazeit (18349 in chips) 
+Seat 8: winghymliu (22474 in chips) 
+Seat 9: no1beyondfan888 (50992 in chips) 
+winghymliu: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [6s Kh]
+hellokwanny: folds 
+pokeher878787: raises 200 to 300
+scra88le56: folds 
+420justblazeit: calls 300
+winghymliu: calls 250
+no1beyondfan888: calls 200
+*** FLOP *** [Kd 6h 8s]
+winghymliu: checks 
+no1beyondfan888: checks 
+pokeher878787: bets 567
+420justblazeit: folds 
+winghymliu: folds 
+no1beyondfan888: calls 567
+*** TURN *** [Kd 6h 8s] [Jd]
+no1beyondfan888: checks 
+pokeher878787: bets 1103
+no1beyondfan888: calls 1103
+*** RIVER *** [Kd 6h 8s Jd] [7h]
+no1beyondfan888: checks 
+pokeher878787: checks 
+*** SHOW DOWN ***
+no1beyondfan888: shows [Tc Qd] (high card King)
+pokeher878787: shows [Qh Qs] (a pair of Queens)
+pokeher878787 collected 4290 from pot
+*** SUMMARY ***
+Total pot 4540 | Rake 250 
+Board [Kd 6h 8s Jd 7h]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 showed [Qh Qs] and won (4290) with a pair of Queens
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit (button) folded on the Flop
+Seat 8: winghymliu (small blind) folded on the Flop
+Seat 9: no1beyondfan888 (big blind) showed [Tc Qd] and lost with high card King
+
+
+
+PokerStars Home Game Hand #211273190980: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:29:59 WET [2020/04/03 18:29:59 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (27159 in chips) 
+Seat 4: pokeher878787 (13672 in chips) 
+Seat 5: scra88le56 (31703 in chips) 
+Seat 6: 420justblazeit (18049 in chips) 
+Seat 8: winghymliu (22174 in chips) 
+Seat 9: no1beyondfan888 (49022 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [7h 9s]
+pokeher878787: calls 100
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: calls 100
+no1beyondfan888: folds 
+hellokwanny: checks 
+*** FLOP *** [Kh Qs Ks]
+hellokwanny: checks 
+pokeher878787: bets 100
+winghymliu: raises 531 to 631
+hellokwanny: folds 
+pokeher878787: folds 
+Uncalled bet (531) returned to winghymliu
+winghymliu collected 520 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 550 | Rake 30 
+Board [Kh Qs Ks]
+Seat 1: hellokwanny (big blind) folded on the Flop
+Seat 4: pokeher878787 folded on the Flop
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu (button) collected (520)
+Seat 9: no1beyondfan888 (small blind) folded before Flop
+
+
+
+PokerStars Home Game Hand #211273254156: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:30:46 WET [2020/04/03 18:30:46 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (27059 in chips) 
+Seat 4: pokeher878787 (13472 in chips) 
+Seat 5: scra88le56 (31703 in chips) 
+Seat 6: 420justblazeit (18049 in chips) 
+Seat 8: winghymliu (22494 in chips) 
+Seat 9: no1beyondfan888 (48972 in chips) 
+hellokwanny: posts small blind 50
+pokeher878787: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Ah 4d]
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: folds 
+no1beyondfan888: folds 
+hellokwanny: calls 50
+pokeher878787: checks 
+*** FLOP *** [Jd 7c 3h]
+hellokwanny: bets 100
+pokeher878787: calls 100
+*** TURN *** [Jd 7c 3h] [Qc]
+hellokwanny: bets 200
+pokeher878787: calls 200
+*** RIVER *** [Jd 7c 3h Qc] [5s]
+hellokwanny: bets 600
+pokeher878787: folds 
+Uncalled bet (600) returned to hellokwanny
+hellokwanny collected 756 from pot
+hellokwanny: doesn't show hand 
+*** SUMMARY ***
+Total pot 800 | Rake 44 
+Board [Jd 7c 3h Qc 5s]
+Seat 1: hellokwanny (small blind) collected (756)
+Seat 4: pokeher878787 (big blind) folded on the River
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 (button) folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211273307024: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:31:30 WET [2020/04/03 18:31:30 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (27415 in chips) 
+Seat 4: pokeher878787 (13072 in chips) 
+Seat 5: scra88le56 (31703 in chips) 
+Seat 6: 420justblazeit (18049 in chips) 
+Seat 8: winghymliu (22494 in chips) 
+Seat 9: no1beyondfan888 (48972 in chips) 
+pokeher878787: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [5c 9h]
+420justblazeit: raises 200 to 300
+winghymliu: raises 700 to 1000
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: folds 
+scra88le56: folds 
+420justblazeit: folds 
+Uncalled bet (700) returned to winghymliu
+winghymliu collected 750 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 750 | Rake 0 
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 4: pokeher878787 (small blind) folded before Flop
+Seat 5: scra88le56 (big blind) folded before Flop
+Seat 6: 420justblazeit folded before Flop
+Seat 8: winghymliu collected (750)
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211273331551: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:31:50 WET [2020/04/03 18:31:50 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #4 is the button
+Seat 1: hellokwanny (27415 in chips) 
+Seat 4: pokeher878787 (13022 in chips) 
+Seat 5: scra88le56 (31603 in chips) 
+Seat 6: 420justblazeit (17749 in chips) 
+Seat 8: winghymliu (22944 in chips) 
+Seat 9: no1beyondfan888 (48972 in chips) 
+scra88le56: posts small blind 50
+420justblazeit: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Ah 7c]
+winghymliu: calls 100
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: raises 200 to 300
+scra88le56: raises 500 to 800
+420justblazeit: folds 
+winghymliu: calls 700
+pokeher878787: calls 500
+*** FLOP *** [6h Td 5d]
+scra88le56: bets 800
+winghymliu: calls 800
+pokeher878787: calls 800
+*** TURN *** [6h Td 5d] [2s]
+scra88le56: bets 800
+winghymliu: calls 800
+pokeher878787: calls 800
+*** RIVER *** [6h Td 5d 2s] [7h]
+scra88le56: bets 800
+winghymliu: calls 800
+pokeher878787: calls 800
+*** SHOW DOWN ***
+scra88le56: shows [Ad Qh] (high card Ace)
+winghymliu: shows [8c 7d] (a pair of Sevens)
+pokeher878787: mucks hand 
+winghymliu collected 9166 from pot
+*** SUMMARY ***
+Total pot 9700 | Rake 534 
+Board [6h Td 5d 2s 7h]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 (button) mucked [6d Ac]
+Seat 5: scra88le56 (small blind) showed [Ad Qh] and lost with high card Ace
+Seat 6: 420justblazeit (big blind) folded before Flop
+Seat 8: winghymliu showed [8c 7d] and won (9166) with a pair of Sevens
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211273423658: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:33:06 WET [2020/04/03 18:33:06 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (27415 in chips) 
+Seat 4: pokeher878787 (9822 in chips) 
+Seat 5: scra88le56 (28403 in chips) 
+Seat 6: 420justblazeit (17649 in chips) 
+Seat 8: winghymliu (28910 in chips) 
+Seat 9: no1beyondfan888 (48972 in chips) 
+420justblazeit: posts small blind 50
+winghymliu: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Js 8h]
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: calls 100
+scra88le56: folds 
+420justblazeit: calls 50
+winghymliu: checks 
+*** FLOP *** [2c 8d 6d]
+420justblazeit: checks 
+winghymliu: bets 400
+pokeher878787: folds 
+420justblazeit: folds 
+Uncalled bet (400) returned to winghymliu
+winghymliu collected 283 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 300 | Rake 17 
+Board [2c 8d 6d]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 folded on the Flop
+Seat 5: scra88le56 (button) folded before Flop (didn't bet)
+Seat 6: 420justblazeit (small blind) folded on the Flop
+Seat 8: winghymliu (big blind) collected (283)
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211273476201: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:33:46 WET [2020/04/03 18:33:46 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (27415 in chips) 
+Seat 4: pokeher878787 (9722 in chips) 
+Seat 5: scra88le56 (28403 in chips) 
+Seat 6: 420justblazeit (17549 in chips) 
+Seat 8: winghymliu (29093 in chips) 
+Seat 9: no1beyondfan888 (48972 in chips) 
+winghymliu: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Th 7d]
+hellokwanny: folds 
+pokeher878787: raises 200 to 300
+scra88le56 has timed out
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: calls 250
+no1beyondfan888: calls 200
+*** FLOP *** [Kh Kd 8s]
+winghymliu: checks 
+no1beyondfan888: bets 100
+pokeher878787: calls 100
+winghymliu: raises 200 to 300
+no1beyondfan888: folds 
+pokeher878787: folds 
+Uncalled bet (200) returned to winghymliu
+winghymliu collected 1134 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 1200 | Rake 66 
+Board [Kh Kd 8s]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 folded on the Flop
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit (button) folded before Flop (didn't bet)
+Seat 8: winghymliu (small blind) collected (1134)
+Seat 9: no1beyondfan888 (big blind) folded on the Flop
+
+
+
+PokerStars Home Game Hand #211273547454: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:34:45 WET [2020/04/03 18:34:45 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (27415 in chips) 
+Seat 4: pokeher878787 (9322 in chips) 
+Seat 6: 420justblazeit (17549 in chips) 
+Seat 8: winghymliu (29827 in chips) 
+Seat 9: no1beyondfan888 (48572 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Tc Td]
+pokeher878787: calls 100
+420justblazeit: folds 
+winghymliu: raises 350 to 450
+no1beyondfan888: calls 400
+hellokwanny: calls 350
+pokeher878787: folds 
+*** FLOP *** [8d Ks Ac]
+no1beyondfan888: checks 
+hellokwanny: checks 
+winghymliu: bets 1370
+no1beyondfan888: folds 
+hellokwanny: folds 
+Uncalled bet (1370) returned to winghymliu
+winghymliu collected 1370 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 1450 | Rake 80 
+Board [8d Ks Ac]
+Seat 1: hellokwanny (big blind) folded on the Flop
+Seat 4: pokeher878787 folded before Flop
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu (button) collected (1370)
+Seat 9: no1beyondfan888 (small blind) folded on the Flop
+
+
+
+PokerStars Home Game Hand #211273595297: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:35:25 WET [2020/04/03 18:35:25 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (26965 in chips) 
+Seat 4: pokeher878787 (9222 in chips) 
+Seat 6: 420justblazeit (17549 in chips) 
+Seat 8: winghymliu (30747 in chips) 
+Seat 9: no1beyondfan888 (48122 in chips) 
+hellokwanny: posts small blind 50
+pokeher878787: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [As 6h]
+420justblazeit: folds 
+winghymliu: calls 100
+no1beyondfan888: calls 100
+hellokwanny: folds 
+pokeher878787: checks 
+*** FLOP *** [Ah Th 3h]
+pokeher878787: checks 
+winghymliu: bets 900
+no1beyondfan888: raises 900 to 1800
+pokeher878787: folds 
+winghymliu: raises 28847 to 30647 and is all-in
+no1beyondfan888: calls 28847
+*** TURN *** [Ah Th 3h] [7c]
+*** RIVER *** [Ah Th 3h 7c] [9c]
+*** SHOW DOWN ***
+winghymliu: shows [8s Ad] (a pair of Aces)
+no1beyondfan888: shows [Ac Tc] (two pair, Aces and Tens)
+no1beyondfan888 collected 58254 from pot
+*** SUMMARY ***
+Total pot 61644 | Rake 3390 
+Board [Ah Th 3h 7c 9c]
+Seat 1: hellokwanny (small blind) folded before Flop
+Seat 4: pokeher878787 (big blind) folded on the Flop
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu showed [8s Ad] and lost with a pair of Aces
+Seat 9: no1beyondfan888 (button) showed [Ac Tc] and won (58254) with two pair, Aces and Tens
+
+
+
+PokerStars Home Game Hand #211273659869: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:36:19 WET [2020/04/03 18:36:19 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (26915 in chips) 
+Seat 4: pokeher878787 (9122 in chips) 
+Seat 6: 420justblazeit (17549 in chips) 
+Seat 9: no1beyondfan888 (75629 in chips) 
+pokeher878787: posts small blind 50
+420justblazeit: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Kh 4d]
+no1beyondfan888: calls 100
+hellokwanny: folds 
+pokeher878787: calls 50
+420justblazeit: checks 
+*** FLOP *** [Qs 2d 5d]
+pokeher878787: checks 
+420justblazeit: checks 
+no1beyondfan888: checks 
+*** TURN *** [Qs 2d 5d] [5s]
+pokeher878787: checks 
+420justblazeit: checks 
+no1beyondfan888: checks 
+*** RIVER *** [Qs 2d 5d 5s] [5h]
+pokeher878787: bets 100
+420justblazeit: calls 100
+no1beyondfan888: raises 291 to 391
+pokeher878787: calls 291
+420justblazeit: folds 
+*** SHOW DOWN ***
+no1beyondfan888: shows [9c 8d] (three of a kind, Fives)
+pokeher878787: shows [Kc 6s] (three of a kind, Fives - King kicker)
+pokeher878787 collected 1117 from pot
+*** SUMMARY ***
+Total pot 1182 | Rake 65 
+Board [Qs 2d 5d 5s 5h]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 4: pokeher878787 (small blind) showed [Kc 6s] and won (1117) with three of a kind, Fives
+Seat 6: 420justblazeit (big blind) folded on the River
+Seat 9: no1beyondfan888 showed [9c 8d] and lost with three of a kind, Fives
+
+
+
+PokerStars Home Game Hand #211273721616: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:37:11 WET [2020/04/03 18:37:11 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #4 is the button
+Seat 1: hellokwanny (26915 in chips) 
+Seat 4: pokeher878787 (9748 in chips) 
+Seat 6: 420justblazeit (17349 in chips) 
+Seat 9: no1beyondfan888 (75138 in chips) 
+420justblazeit: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [6s Ad]
+hellokwanny: folds 
+pokeher878787: calls 100
+420justblazeit: folds 
+no1beyondfan888: checks 
+*** FLOP *** [Jd 4s As]
+no1beyondfan888: checks 
+pokeher878787: bets 118
+no1beyondfan888 has timed out
+no1beyondfan888: folds 
+Uncalled bet (118) returned to pokeher878787
+pokeher878787 collected 236 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 250 | Rake 14 
+Board [Jd 4s As]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 (button) collected (236)
+Seat 6: 420justblazeit (small blind) folded before Flop
+Seat 9: no1beyondfan888 (big blind) folded on the Flop
+
+
+
+PokerStars Home Game Hand #211273781687: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:38:02 WET [2020/04/03 18:38:02 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (26915 in chips) 
+Seat 4: pokeher878787 (9884 in chips) 
+Seat 6: 420justblazeit (17299 in chips) 
+hellokwanny: posts small blind 50
+pokeher878787: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [5d Kc]
+420justblazeit: folds 
+hellokwanny: folds 
+Uncalled bet (50) returned to pokeher878787
+pokeher878787 collected 100 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 100 | Rake 0 
+Seat 1: hellokwanny (small blind) folded before Flop
+Seat 4: pokeher878787 (big blind) collected (100)
+Seat 6: 420justblazeit (button) folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211273793184: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:38:11 WET [2020/04/03 18:38:11 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (26865 in chips) 
+Seat 4: pokeher878787 (9934 in chips) 
+Seat 6: 420justblazeit (17299 in chips) 
+Seat 9: no1beyondfan888 (75038 in chips) 
+pokeher878787: posts small blind 50
+420justblazeit: posts big blind 100
+no1beyondfan888: posts small blind 50
+*** HOLE CARDS ***
+Dealt to hellokwanny [3d 8c]
+scra88le56 is disconnected 
+no1beyondfan888: calls 100
+hellokwanny: folds 
+pokeher878787: calls 50
+420justblazeit: checks 
+*** FLOP *** [4c Tc 2d]
+pokeher878787: bets 331
+420justblazeit: folds 
+no1beyondfan888: calls 331
+*** TURN *** [4c Tc 2d] [6h]
+pokeher878787: bets 956
+no1beyondfan888: calls 956
+*** RIVER *** [4c Tc 2d 6h] [Ah]
+pokeher878787: bets 2763
+no1beyondfan888: raises 2763 to 5526
+pokeher878787: raises 3021 to 8547 and is all-in
+no1beyondfan888: calls 3021
+*** SHOW DOWN ***
+pokeher878787: shows [Th 6s] (two pair, Tens and Sixes)
+no1beyondfan888: shows [6d Ac] (two pair, Aces and Sixes)
+no1beyondfan888 collected 18917 from pot
+*** SUMMARY ***
+Total pot 20018 | Rake 1101 
+Board [4c Tc 2d 6h Ah]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 4: pokeher878787 (small blind) showed [Th 6s] and lost with two pair, Tens and Sixes
+Seat 6: 420justblazeit (big blind) folded on the Flop
+Seat 9: no1beyondfan888 showed [6d Ac] and won (18917) with two pair, Aces and Sixes
+
+
+
+PokerStars Home Game Hand #211273846205: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:38:56 WET [2020/04/03 18:38:56 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (26865 in chips) 
+Seat 6: 420justblazeit (17199 in chips) 
+Seat 9: no1beyondfan888 (83971 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+scra88le56 has timed out
+scra88le56: is sitting out 
+*** HOLE CARDS ***
+Dealt to hellokwanny [Td 2s]
+scra88le56 is disconnected 
+420justblazeit: folds 
+no1beyondfan888: calls 50
+hellokwanny: checks 
+*** FLOP *** [4d 9c Qh]
+no1beyondfan888: checks 
+hellokwanny: checks 
+*** TURN *** [4d 9c Qh] [3s]
+no1beyondfan888: bets 100
+hellokwanny: folds 
+Uncalled bet (100) returned to no1beyondfan888
+no1beyondfan888 collected 189 from pot
+no1beyondfan888: doesn't show hand 
+*** SUMMARY ***
+Total pot 200 | Rake 11 
+Board [4d 9c Qh 3s]
+Seat 1: hellokwanny (big blind) folded on the Turn
+Seat 6: 420justblazeit (button) folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 (small blind) collected (189)
+
+
+
+PokerStars Home Game Hand #211273889762: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:39:33 WET [2020/04/03 18:39:33 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (26765 in chips) 
+Seat 6: 420justblazeit (17199 in chips) 
+Seat 9: no1beyondfan888 (84060 in chips) 
+hellokwanny: posts small blind 50
+420justblazeit: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Jd 7d]
+no1beyondfan888: folds 
+hellokwanny: raises 200 to 300
+420justblazeit: folds 
+Uncalled bet (200) returned to hellokwanny
+hellokwanny collected 200 from pot
+hellokwanny: doesn't show hand 
+*** SUMMARY ***
+Total pot 200 | Rake 0 
+Seat 1: hellokwanny (small blind) collected (200)
+Seat 6: 420justblazeit (big blind) folded before Flop
+Seat 9: no1beyondfan888 (button) folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211273915974: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:39:53 WET [2020/04/03 18:39:53 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (26865 in chips) 
+Seat 6: 420justblazeit (17099 in chips) 
+Seat 9: no1beyondfan888 (84060 in chips) 
+420justblazeit: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [3d Ks]
+hellokwanny: folds 
+420justblazeit: calls 50
+no1beyondfan888: checks 
+*** FLOP *** [Ah Tc 4s]
+420justblazeit: checks 
+no1beyondfan888: bets 189
+420justblazeit: folds 
+Uncalled bet (189) returned to no1beyondfan888
+no1beyondfan888 collected 189 from pot
+no1beyondfan888: doesn't show hand 
+*** SUMMARY ***
+Total pot 200 | Rake 11 
+Board [Ah Tc 4s]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 6: 420justblazeit (small blind) folded on the Flop
+Seat 9: no1beyondfan888 (big blind) collected (189)
+
+
+
+PokerStars Home Game Hand #211273933682: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:40:08 WET [2020/04/03 18:40:08 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (26865 in chips) 
+Seat 5: scra88le56 (28403 in chips) 
+Seat 6: 420justblazeit (16999 in chips) 
+Seat 9: no1beyondfan888 (84149 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+scra88le56: posts small & big blinds 150
+*** HOLE CARDS ***
+Dealt to hellokwanny [7d Ts]
+scra88le56: checks 
+420justblazeit: folds 
+no1beyondfan888: calls 50
+hellokwanny: checks 
+*** FLOP *** [5d 7h Ks]
+no1beyondfan888: checks 
+hellokwanny: bets 200
+scra88le56: folds 
+no1beyondfan888: calls 200
+*** TURN *** [5d 7h Ks] [Jd]
+no1beyondfan888: checks 
+hellokwanny: checks 
+*** RIVER *** [5d 7h Ks Jd] [Td]
+no1beyondfan888: bets 709
+hellokwanny: calls 709
+*** SHOW DOWN ***
+no1beyondfan888: shows [Th 2h] (a pair of Tens)
+hellokwanny: shows [7d Ts] (two pair, Tens and Sevens)
+hellokwanny collected 2049 from pot
+*** SUMMARY ***
+Total pot 2168 | Rake 119 
+Board [5d 7h Ks Jd Td]
+Seat 1: hellokwanny (big blind) showed [7d Ts] and won (2049) with two pair, Tens and Sevens
+Seat 5: scra88le56 folded on the Flop (didn't bet)
+Seat 6: 420justblazeit (button) folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 (small blind) showed [Th 2h] and lost with a pair of Tens
+
+
+
+PokerStars Home Game Hand #211273989449: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:40:55 WET [2020/04/03 18:40:55 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (27905 in chips) 
+Seat 5: scra88le56 (28253 in chips) 
+Seat 6: 420justblazeit (16999 in chips) 
+Seat 9: no1beyondfan888 (83140 in chips) 
+hellokwanny: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Tc 2c]
+420justblazeit: raises 400 to 500
+no1beyondfan888: calls 500
+hellokwanny: folds 
+scra88le56: calls 400
+*** FLOP *** [6s 7d 3s]
+scra88le56: checks 
+420justblazeit: bets 1465
+no1beyondfan888: folds 
+scra88le56: folds 
+Uncalled bet (1465) returned to 420justblazeit
+420justblazeit collected 1465 from pot
+420justblazeit: doesn't show hand 
+*** SUMMARY ***
+Total pot 1550 | Rake 85 
+Board [6s 7d 3s]
+Seat 1: hellokwanny (small blind) folded before Flop
+Seat 5: scra88le56 (big blind) folded on the Flop
+Seat 6: 420justblazeit collected (1465)
+Seat 9: no1beyondfan888 (button) folded on the Flop
+
+
+
+PokerStars Home Game Hand #211274025274: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:41:26 WET [2020/04/03 18:41:26 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (27855 in chips) 
+Seat 5: scra88le56 (27753 in chips) 
+Seat 6: 420justblazeit (17964 in chips) 
+Seat 9: no1beyondfan888 (82640 in chips) 
+scra88le56: posts small blind 50
+420justblazeit: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [5d 2h]
+no1beyondfan888: raises 100 to 200
+hellokwanny: folds 
+scra88le56: folds 
+420justblazeit: folds 
+Uncalled bet (100) returned to no1beyondfan888
+no1beyondfan888 collected 250 from pot
+no1beyondfan888: doesn't show hand 
+*** SUMMARY ***
+Total pot 250 | Rake 0 
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 5: scra88le56 (small blind) folded before Flop
+Seat 6: 420justblazeit (big blind) folded before Flop
+Seat 9: no1beyondfan888 collected (250)
+
+
+
+PokerStars Home Game Hand #211274038797: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:41:37 WET [2020/04/03 18:41:37 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (27855 in chips) 
+Seat 5: scra88le56 (27703 in chips) 
+Seat 6: 420justblazeit (17864 in chips) 
+Seat 9: no1beyondfan888 (82790 in chips) 
+420justblazeit: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Ac 8c]
+hellokwanny: raises 200 to 300
+scra88le56: folds 
+420justblazeit: folds 
+no1beyondfan888: calls 200
+*** FLOP *** [2d Kd Kh]
+no1beyondfan888: checks 
+hellokwanny: bets 300
+no1beyondfan888: calls 300
+*** TURN *** [2d Kd Kh] [2h]
+no1beyondfan888: checks 
+hellokwanny: bets 500
+no1beyondfan888: calls 500
+*** RIVER *** [2d Kd Kh 2h] [Ts]
+no1beyondfan888: checks 
+hellokwanny: checks 
+*** SHOW DOWN ***
+no1beyondfan888: shows [Qc As] (two pair, Kings and Deuces)
+hellokwanny: shows [Ac 8c] (two pair, Kings and Deuces)
+no1beyondfan888 collected 1063 from pot
+hellokwanny collected 1063 from pot
+*** SUMMARY ***
+Total pot 2250 | Rake 124 
+Board [2d Kd Kh 2h Ts]
+Seat 1: hellokwanny showed [Ac 8c] and won (1063) with two pair, Kings and Deuces
+Seat 5: scra88le56 (button) folded before Flop (didn't bet)
+Seat 6: 420justblazeit (small blind) folded before Flop
+Seat 9: no1beyondfan888 (big blind) showed [Qc As] and won (1063) with two pair, Kings and Deuces
+
+
+
+PokerStars Home Game Hand #211274084996: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:42:17 WET [2020/04/03 18:42:17 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (27818 in chips) 
+Seat 5: scra88le56 (27703 in chips) 
+Seat 6: 420justblazeit (17814 in chips) 
+Seat 9: no1beyondfan888 (82753 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Qc 4h]
+scra88le56: folds 
+420justblazeit: folds 
+no1beyondfan888: raises 100 to 200
+hellokwanny: folds 
+Uncalled bet (100) returned to no1beyondfan888
+no1beyondfan888 collected 200 from pot
+no1beyondfan888: doesn't show hand 
+*** SUMMARY ***
+Total pot 200 | Rake 0 
+Seat 1: hellokwanny (big blind) folded before Flop
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit (button) folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 (small blind) collected (200)
+
+
+
+PokerStars Home Game Hand #211274097425: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:42:27 WET [2020/04/03 18:42:27 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (27718 in chips) 
+Seat 5: scra88le56 (27703 in chips) 
+Seat 6: 420justblazeit (17814 in chips) 
+Seat 9: no1beyondfan888 (82853 in chips) 
+hellokwanny: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Jc Qs]
+420justblazeit: folds 
+no1beyondfan888: calls 100
+hellokwanny: raises 300 to 400
+scra88le56: calls 300
+no1beyondfan888: calls 300
+*** FLOP *** [Jh Ac 4h]
+hellokwanny: bets 567
+scra88le56: calls 567
+no1beyondfan888: calls 567
+*** TURN *** [Jh Ac 4h] [3d]
+hellokwanny: bets 1370
+scra88le56: calls 1370
+no1beyondfan888: calls 1370
+*** RIVER *** [Jh Ac 4h 3d] [2h]
+hellokwanny: checks 
+scra88le56: bets 2200
+no1beyondfan888: calls 2200
+hellokwanny: folds 
+*** SHOW DOWN ***
+scra88le56: shows [As 8h] (a pair of Aces)
+no1beyondfan888: mucks hand 
+scra88le56 collected 10783 from pot
+*** SUMMARY ***
+Total pot 11411 | Rake 628 
+Board [Jh Ac 4h 3d 2h]
+Seat 1: hellokwanny (small blind) folded on the River
+Seat 5: scra88le56 (big blind) showed [As 8h] and won (10783) with a pair of Aces
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 (button) mucked [Ad 7h]
+
+
+
+PokerStars Home Game Hand #211274136591: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:43:01 WET [2020/04/03 18:43:01 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (25381 in chips) 
+Seat 5: scra88le56 (33949 in chips) 
+Seat 6: 420justblazeit (17814 in chips) 
+Seat 9: no1beyondfan888 (78316 in chips) 
+scra88le56: posts small blind 50
+420justblazeit: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [9c 2d]
+no1beyondfan888: folds 
+hellokwanny: folds 
+scra88le56: calls 50
+420justblazeit: checks 
+*** FLOP *** [7d 6d 3s]
+scra88le56: checks 
+420justblazeit: bets 200
+scra88le56: folds 
+Uncalled bet (200) returned to 420justblazeit
+420justblazeit collected 189 from pot
+420justblazeit: doesn't show hand 
+*** SUMMARY ***
+Total pot 200 | Rake 11 
+Board [7d 6d 3s]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 5: scra88le56 (small blind) folded on the Flop
+Seat 6: 420justblazeit (big blind) collected (189)
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211274174327: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:43:34 WET [2020/04/03 18:43:34 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (25381 in chips) 
+Seat 5: scra88le56 (33849 in chips) 
+Seat 6: 420justblazeit (17903 in chips) 
+Seat 9: no1beyondfan888 (78316 in chips) 
+420justblazeit: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [7d 2c]
+hellokwanny: folds 
+scra88le56: raises 400 to 500
+420justblazeit: folds 
+no1beyondfan888: folds 
+Uncalled bet (400) returned to scra88le56
+scra88le56 collected 250 from pot
+scra88le56: doesn't show hand 
+*** SUMMARY ***
+Total pot 250 | Rake 0 
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 5: scra88le56 (button) collected (250)
+Seat 6: 420justblazeit (small blind) folded before Flop
+Seat 9: no1beyondfan888 (big blind) folded before Flop
+
+
+
+PokerStars Home Game Hand #211274191406: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:43:47 WET [2020/04/03 18:43:47 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (25381 in chips) 
+Seat 5: scra88le56 (33999 in chips) 
+Seat 6: 420justblazeit (17853 in chips) 
+Seat 9: no1beyondfan888 (78216 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [4s 5d]
+scra88le56: folds 
+420justblazeit: raises 200 to 300
+no1beyondfan888: calls 250
+hellokwanny: folds 
+*** FLOP *** [8h 7s Kd]
+no1beyondfan888: checks 
+420justblazeit: checks 
+*** TURN *** [8h 7s Kd] [5c]
+no1beyondfan888: bets 100
+420justblazeit: calls 100
+*** RIVER *** [8h 7s Kd 5c] [6s]
+no1beyondfan888: bets 425
+420justblazeit: folds 
+Uncalled bet (425) returned to no1beyondfan888
+no1beyondfan888 collected 850 from pot
+no1beyondfan888: doesn't show hand 
+*** SUMMARY ***
+Total pot 900 | Rake 50 
+Board [8h 7s Kd 5c 6s]
+Seat 1: hellokwanny (big blind) folded before Flop
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit (button) folded on the River
+Seat 9: no1beyondfan888 (small blind) collected (850)
+
+
+
+PokerStars Home Game Hand #211274232468: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:44:22 WET [2020/04/03 18:44:22 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (25281 in chips) 
+Seat 5: scra88le56 (33999 in chips) 
+Seat 6: 420justblazeit (17453 in chips) 
+Seat 9: no1beyondfan888 (78666 in chips) 
+hellokwanny: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Td 9s]
+420justblazeit: folds 
+no1beyondfan888: calls 100
+hellokwanny: folds 
+scra88le56: checks 
+*** FLOP *** [Th Jd As]
+scra88le56: bets 100
+no1beyondfan888: raises 100 to 200
+scra88le56: calls 100
+*** TURN *** [Th Jd As] [8s]
+scra88le56: checks 
+no1beyondfan888: bets 614
+scra88le56: calls 614
+*** RIVER *** [Th Jd As 8s] [Ts]
+scra88le56: bets 900
+no1beyondfan888: raises 900 to 1800
+scra88le56: folds 
+Uncalled bet (900) returned to no1beyondfan888
+no1beyondfan888 collected 3476 from pot
+no1beyondfan888: doesn't show hand 
+*** SUMMARY ***
+Total pot 3678 | Rake 202 
+Board [Th Jd As 8s Ts]
+Seat 1: hellokwanny (small blind) folded before Flop
+Seat 5: scra88le56 (big blind) folded on the River
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 (button) collected (3476)
+
+
+
+PokerStars Home Game Hand #211274300677: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:45:16 WET [2020/04/03 18:45:16 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (25231 in chips) 
+Seat 5: scra88le56 (32185 in chips) 
+Seat 6: 420justblazeit (17453 in chips) 
+Seat 9: no1beyondfan888 (80328 in chips) 
+scra88le56: posts small blind 50
+420justblazeit: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [7d As]
+no1beyondfan888: calls 100
+hellokwanny: folds 
+scra88le56: folds 
+420justblazeit: checks 
+*** FLOP *** [Ah 8c 7c]
+420justblazeit: checks 
+no1beyondfan888: bets 100
+420justblazeit: calls 100
+*** TURN *** [Ah 8c 7c] [7s]
+420justblazeit: checks 
+no1beyondfan888: bets 212
+420justblazeit: folds 
+Uncalled bet (212) returned to no1beyondfan888
+no1beyondfan888 collected 425 from pot
+no1beyondfan888: doesn't show hand 
+*** SUMMARY ***
+Total pot 450 | Rake 25 
+Board [Ah 8c 7c 7s]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 5: scra88le56 (small blind) folded before Flop
+Seat 6: 420justblazeit (big blind) folded on the Turn
+Seat 9: no1beyondfan888 collected (425)
+
+
+
+PokerStars Home Game Hand #211274355721: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:46:03 WET [2020/04/03 18:46:03 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (25231 in chips) 
+Seat 5: scra88le56 (32135 in chips) 
+Seat 6: 420justblazeit (17253 in chips) 
+Seat 9: no1beyondfan888 (80553 in chips) 
+420justblazeit: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [2s Td]
+hellokwanny: folds 
+scra88le56: folds 
+420justblazeit: raises 200 to 300
+no1beyondfan888: raises 200 to 500
+420justblazeit: calls 200
+*** FLOP *** [Ah 6c Kc]
+420justblazeit: checks 
+no1beyondfan888: bets 945
+420justblazeit: calls 945
+*** TURN *** [Ah 6c Kc] [Ad]
+420justblazeit: checks 
+no1beyondfan888: bets 2731
+420justblazeit: folds 
+Uncalled bet (2731) returned to no1beyondfan888
+no1beyondfan888 collected 2731 from pot
+no1beyondfan888: doesn't show hand 
+*** SUMMARY ***
+Total pot 2890 | Rake 159 
+Board [Ah 6c Kc Ad]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 5: scra88le56 (button) folded before Flop (didn't bet)
+Seat 6: 420justblazeit (small blind) folded on the Turn
+Seat 9: no1beyondfan888 (big blind) collected (2731)
+
+
+
+PokerStars Home Game Hand #211274404672: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:46:45 WET [2020/04/03 18:46:45 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (25231 in chips) 
+Seat 5: scra88le56 (32135 in chips) 
+Seat 6: 420justblazeit (15808 in chips) 
+Seat 9: no1beyondfan888 (81839 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [4s 8c]
+scra88le56: folds 
+420justblazeit: calls 100
+no1beyondfan888: folds 
+hellokwanny: checks 
+*** FLOP *** [7c 4c Tc]
+hellokwanny: bets 100
+420justblazeit: raises 218 to 318
+hellokwanny: calls 218
+*** TURN *** [7c 4c Tc] [7s]
+hellokwanny: checks 
+420justblazeit: bets 418
+hellokwanny: folds 
+Uncalled bet (418) returned to 420justblazeit
+420justblazeit collected 837 from pot
+420justblazeit: doesn't show hand 
+*** SUMMARY ***
+Total pot 886 | Rake 49 
+Board [7c 4c Tc 7s]
+Seat 1: hellokwanny (big blind) folded on the Turn
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit (button) collected (837)
+Seat 9: no1beyondfan888 (small blind) folded before Flop
+
+
+
+PokerStars Home Game Hand #211274447539: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:47:22 WET [2020/04/03 18:47:22 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (24813 in chips) 
+Seat 5: scra88le56 (32135 in chips) 
+Seat 6: 420justblazeit (16227 in chips) 
+Seat 9: no1beyondfan888 (81789 in chips) 
+hellokwanny: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [7c Jc]
+420justblazeit: folds 
+no1beyondfan888: raises 100 to 200
+hellokwanny: folds 
+scra88le56: calls 100
+*** FLOP *** [Kd 6h Th]
+scra88le56: checks 
+no1beyondfan888: checks 
+*** TURN *** [Kd 6h Th] [Tc]
+scra88le56: checks 
+no1beyondfan888: checks 
+*** RIVER *** [Kd 6h Th Tc] [5s]
+scra88le56: checks 
+no1beyondfan888: bets 425
+scra88le56: calls 425
+*** SHOW DOWN ***
+no1beyondfan888: shows [3c 3s] (two pair, Tens and Threes)
+scra88le56: mucks hand 
+no1beyondfan888 collected 1228 from pot
+*** SUMMARY ***
+Total pot 1300 | Rake 72 
+Board [Kd 6h Th Tc 5s]
+Seat 1: hellokwanny (small blind) folded before Flop
+Seat 5: scra88le56 (big blind) mucked [Qh 4d]
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 (button) showed [3c 3s] and won (1228) with two pair, Tens and Threes
+
+
+
+PokerStars Home Game Hand #211274481992: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:47:52 WET [2020/04/03 18:47:52 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (24763 in chips) 
+Seat 5: scra88le56 (31510 in chips) 
+Seat 6: 420justblazeit (16227 in chips) 
+Seat 9: no1beyondfan888 (82392 in chips) 
+scra88le56: posts small blind 50
+420justblazeit: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Qh Ad]
+no1beyondfan888: raises 100 to 200
+hellokwanny: raises 200 to 400
+scra88le56: calls 350
+420justblazeit: folds 
+no1beyondfan888: calls 200
+*** FLOP *** [6d 4h 6s]
+scra88le56: bets 100
+no1beyondfan888: calls 100
+hellokwanny: calls 100
+*** TURN *** [6d 4h 6s] [Jc]
+scra88le56: checks 
+no1beyondfan888: checks 
+hellokwanny: bets 300
+scra88le56: folds 
+no1beyondfan888: raises 300 to 600
+hellokwanny: calls 300
+*** RIVER *** [6d 4h 6s Jc] [Js]
+no1beyondfan888: checks 
+hellokwanny: bets 1300
+no1beyondfan888: folds 
+Uncalled bet (1300) returned to hellokwanny
+hellokwanny collected 2646 from pot
+hellokwanny: doesn't show hand 
+*** SUMMARY ***
+Total pot 2800 | Rake 154 
+Board [6d 4h 6s Jc Js]
+Seat 1: hellokwanny (button) collected (2646)
+Seat 5: scra88le56 (small blind) folded on the Turn
+Seat 6: 420justblazeit (big blind) folded before Flop
+Seat 9: no1beyondfan888 folded on the River
+
+
+
+PokerStars Home Game Hand #211274532772: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:48:36 WET [2020/04/03 18:48:36 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (26309 in chips) 
+Seat 5: scra88le56 (31010 in chips) 
+Seat 6: 420justblazeit (16127 in chips) 
+Seat 9: no1beyondfan888 (81292 in chips) 
+420justblazeit: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [4h Kh]
+hellokwanny: folds 
+scra88le56: calls 100
+420justblazeit: calls 50
+no1beyondfan888: checks 
+*** FLOP *** [Jc Jh 8c]
+420justblazeit: checks 
+no1beyondfan888: checks 
+scra88le56: bets 100
+420justblazeit: calls 100
+no1beyondfan888: folds 
+*** TURN *** [Jc Jh 8c] [6h]
+420justblazeit: checks 
+scra88le56: bets 300
+420justblazeit: folds 
+Uncalled bet (300) returned to scra88le56
+scra88le56 collected 472 from pot
+scra88le56: doesn't show hand 
+*** SUMMARY ***
+Total pot 500 | Rake 28 
+Board [Jc Jh 8c 6h]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 5: scra88le56 (button) collected (472)
+Seat 6: 420justblazeit (small blind) folded on the Turn
+Seat 9: no1beyondfan888 (big blind) folded on the Flop
+
+
+
+PokerStars Home Game Hand #211274568315: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:49:07 WET [2020/04/03 18:49:07 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (26309 in chips) 
+Seat 5: scra88le56 (31282 in chips) 
+Seat 6: 420justblazeit (15927 in chips) 
+hellokwanny: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [As Ad]
+420justblazeit: folds 
+hellokwanny: raises 100 to 200
+scra88le56: calls 100
+*** FLOP *** [6s Th Qs]
+hellokwanny: bets 252
+scra88le56: folds 
+Uncalled bet (252) returned to hellokwanny
+hellokwanny collected 378 from pot
+hellokwanny: doesn't show hand 
+*** SUMMARY ***
+Total pot 400 | Rake 22 
+Board [6s Th Qs]
+Seat 1: hellokwanny (small blind) collected (378)
+Seat 5: scra88le56 (big blind) folded on the Flop
+Seat 6: 420justblazeit (button) folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211274592138: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:49:28 WET [2020/04/03 18:49:28 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (26487 in chips) 
+Seat 5: scra88le56 (31082 in chips) 
+Seat 6: 420justblazeit (15927 in chips) 
+Seat 8: winghymliu (10000 in chips) 
+scra88le56: posts small blind 50
+420justblazeit: posts big blind 100
+winghymliu: posts small & big blinds 150
+*** HOLE CARDS ***
+Dealt to hellokwanny [Kc 9s]
+winghymliu: checks 
+hellokwanny: raises 150 to 250
+scra88le56: raises 450 to 700
+420justblazeit: folds 
+winghymliu: folds 
+hellokwanny: folds 
+Uncalled bet (450) returned to scra88le56
+scra88le56 collected 750 from pot
+scra88le56: doesn't show hand 
+*** SUMMARY ***
+Total pot 750 | Rake 0 
+Seat 1: hellokwanny (button) folded before Flop
+Seat 5: scra88le56 (small blind) collected (750)
+Seat 6: 420justblazeit (big blind) folded before Flop
+Seat 8: winghymliu folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211274618788: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:49:43 WET [2020/04/03 18:49:43 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (26237 in chips) 
+Seat 5: scra88le56 (31582 in chips) 
+Seat 6: 420justblazeit (15827 in chips) 
+Seat 8: winghymliu (9850 in chips) 
+Seat 9: no1beyondfan888 (81192 in chips) 
+420justblazeit: posts small blind 50
+winghymliu: posts big blind 100
+no1beyondfan888: posts small blind 50
+*** HOLE CARDS ***
+Dealt to hellokwanny [Qc Qh]
+no1beyondfan888: raises 100 to 200
+hellokwanny: raises 400 to 600
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: calls 500
+no1beyondfan888: calls 400
+*** FLOP *** [8h 3c Ts]
+winghymliu: checks 
+no1beyondfan888: bets 100
+hellokwanny: raises 997 to 1097
+winghymliu: folds 
+no1beyondfan888: folds 
+Uncalled bet (997) returned to hellokwanny
+hellokwanny collected 1984 from pot
+hellokwanny: doesn't show hand 
+*** SUMMARY ***
+Total pot 2100 | Rake 116 
+Board [8h 3c Ts]
+Seat 1: hellokwanny collected (1984)
+Seat 5: scra88le56 (button) folded before Flop (didn't bet)
+Seat 6: 420justblazeit (small blind) folded before Flop
+Seat 8: winghymliu (big blind) folded on the Flop
+Seat 9: no1beyondfan888 folded on the Flop
+
+
+
+PokerStars Home Game Hand #211274657966: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:50:17 WET [2020/04/03 18:50:17 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (27521 in chips) 
+Seat 5: scra88le56 (31582 in chips) 
+Seat 6: 420justblazeit (15777 in chips) 
+Seat 8: winghymliu (9250 in chips) 
+Seat 9: no1beyondfan888 (80442 in chips) 
+winghymliu: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Ks Ac]
+hellokwanny: raises 400 to 500
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: folds 
+no1beyondfan888: folds 
+Uncalled bet (400) returned to hellokwanny
+hellokwanny collected 250 from pot
+hellokwanny: doesn't show hand 
+*** SUMMARY ***
+Total pot 250 | Rake 0 
+Seat 1: hellokwanny collected (250)
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit (button) folded before Flop (didn't bet)
+Seat 8: winghymliu (small blind) folded before Flop
+Seat 9: no1beyondfan888 (big blind) folded before Flop
+
+
+
+PokerStars Home Game Hand #211274668647: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:50:26 WET [2020/04/03 18:50:26 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (27671 in chips) 
+Seat 5: scra88le56 (31582 in chips) 
+Seat 6: 420justblazeit (15777 in chips) 
+Seat 8: winghymliu (9200 in chips) 
+Seat 9: no1beyondfan888 (80342 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [5h 3s]
+scra88le56: raises 100 to 200
+420justblazeit: calls 200
+winghymliu: raises 100 to 300
+no1beyondfan888: calls 250
+hellokwanny: folds 
+scra88le56: calls 100
+420justblazeit: calls 100
+*** FLOP *** [7s 9h 8c]
+no1beyondfan888: checks 
+scra88le56: checks 
+420justblazeit: checks 
+winghymliu: bets 1228
+no1beyondfan888: raises 1228 to 2456
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: folds 
+Uncalled bet (1228) returned to no1beyondfan888
+no1beyondfan888 collected 3549 from pot
+no1beyondfan888: doesn't show hand 
+*** SUMMARY ***
+Total pot 3756 | Rake 207 
+Board [7s 9h 8c]
+Seat 1: hellokwanny (big blind) folded before Flop
+Seat 5: scra88le56 folded on the Flop
+Seat 6: 420justblazeit folded on the Flop
+Seat 8: winghymliu (button) folded on the Flop
+Seat 9: no1beyondfan888 (small blind) collected (3549)
+
+
+
+PokerStars Home Game Hand #211274732688: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:51:23 WET [2020/04/03 18:51:23 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (27571 in chips) 
+Seat 5: scra88le56 (31282 in chips) 
+Seat 6: 420justblazeit (15477 in chips) 
+Seat 8: winghymliu (7672 in chips) 
+Seat 9: no1beyondfan888 (82363 in chips) 
+hellokwanny: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [6c 9d]
+420justblazeit: folds 
+winghymliu: calls 100
+no1beyondfan888: folds 
+hellokwanny: folds 
+scra88le56: checks 
+*** FLOP *** [5s 5d Qs]
+scra88le56: checks 
+winghymliu: checks 
+*** TURN *** [5s 5d Qs] [Kh]
+scra88le56: checks 
+winghymliu: bets 236
+scra88le56: raises 236 to 472
+winghymliu: raises 236 to 708
+scra88le56: raises 792 to 1500
+winghymliu: raises 792 to 2292
+scra88le56: raises 26292 to 28584
+winghymliu: calls 5280 and is all-in
+Uncalled bet (21012) returned to scra88le56
+*** RIVER *** [5s 5d Qs Kh] [Qc]
+*** SHOW DOWN ***
+scra88le56: shows [5c Js] (a full house, Fives full of Queens)
+winghymliu: shows [5h 4h] (a full house, Fives full of Queens)
+scra88le56 collected 7274 from pot
+winghymliu collected 7273 from pot
+*** SUMMARY ***
+Total pot 15394 | Rake 847 
+Board [5s 5d Qs Kh Qc]
+Seat 1: hellokwanny (small blind) folded before Flop
+Seat 5: scra88le56 (big blind) showed [5c Js] and won (7274) with a full house, Fives full of Queens
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu showed [5h 4h] and won (7273) with a full house, Fives full of Queens
+Seat 9: no1beyondfan888 (button) folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211274789472: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:52:12 WET [2020/04/03 18:52:12 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (27521 in chips) 
+Seat 5: scra88le56 (30884 in chips) 
+Seat 6: 420justblazeit (15477 in chips) 
+Seat 8: winghymliu (7273 in chips) 
+Seat 9: no1beyondfan888 (82363 in chips) 
+scra88le56: posts small blind 50
+420justblazeit: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Js 9c]
+winghymliu: calls 100
+no1beyondfan888: folds 
+hellokwanny: folds 
+scra88le56: calls 50
+420justblazeit: checks 
+*** FLOP *** [Ad 8s As]
+scra88le56: bets 300
+420justblazeit: folds 
+winghymliu: folds 
+Uncalled bet (300) returned to scra88le56
+scra88le56 collected 283 from pot
+scra88le56: doesn't show hand 
+*** SUMMARY ***
+Total pot 300 | Rake 17 
+Board [Ad 8s As]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 5: scra88le56 (small blind) collected (283)
+Seat 6: 420justblazeit (big blind) folded on the Flop
+Seat 8: winghymliu folded on the Flop
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211274825687: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:52:44 WET [2020/04/03 18:52:44 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (27521 in chips) 
+Seat 5: scra88le56 (31067 in chips) 
+Seat 6: 420justblazeit (15377 in chips) 
+Seat 8: winghymliu (7173 in chips) 
+Seat 9: no1beyondfan888 (82363 in chips) 
+420justblazeit: posts small blind 50
+winghymliu: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Js Kc]
+no1beyondfan888: folds 
+hellokwanny: raises 300 to 400
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: calls 300
+*** FLOP *** [Ac 7c 5s]
+winghymliu: bets 100
+hellokwanny: calls 100
+*** TURN *** [Ac 7c 5s] [6h]
+winghymliu: bets 100
+hellokwanny: calls 100
+*** RIVER *** [Ac 7c 5s 6h] [3d]
+winghymliu: bets 2100
+hellokwanny: folds 
+Uncalled bet (2100) returned to winghymliu
+winghymliu collected 1181 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 1250 | Rake 69 
+Board [Ac 7c 5s 6h 3d]
+Seat 1: hellokwanny folded on the River
+Seat 5: scra88le56 (button) folded before Flop (didn't bet)
+Seat 6: 420justblazeit (small blind) folded before Flop
+Seat 8: winghymliu (big blind) collected (1181)
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211274891602: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:53:39 WET [2020/04/03 18:53:39 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (26921 in chips) 
+Seat 5: scra88le56 (31067 in chips) 
+Seat 6: 420justblazeit (15327 in chips) 
+Seat 8: winghymliu (7754 in chips) 
+Seat 9: no1beyondfan888 (82363 in chips) 
+winghymliu: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Jh 5c]
+hellokwanny: folds 
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: folds 
+Uncalled bet (50) returned to no1beyondfan888
+no1beyondfan888 collected 100 from pot
+no1beyondfan888: doesn't show hand 
+*** SUMMARY ***
+Total pot 100 | Rake 0 
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit (button) folded before Flop (didn't bet)
+Seat 8: winghymliu (small blind) folded before Flop
+Seat 9: no1beyondfan888 (big blind) collected (100)
+
+
+
+PokerStars Home Game Hand #211274909394: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:53:54 WET [2020/04/03 18:53:54 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (26921 in chips) 
+Seat 4: pokeher878787 (10000 in chips) 
+Seat 5: scra88le56 (31067 in chips) 
+Seat 6: 420justblazeit (15327 in chips) 
+Seat 8: winghymliu (7704 in chips) 
+Seat 9: no1beyondfan888 (82413 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+pokeher878787: posts small & big blinds 150
+*** HOLE CARDS ***
+Dealt to hellokwanny [7c Qs]
+pokeher878787: checks 
+scra88le56: folds 
+420justblazeit: calls 100
+winghymliu: raises 100 to 200
+no1beyondfan888: raises 100 to 300
+hellokwanny: folds 
+pokeher878787: calls 200
+420justblazeit: folds 
+winghymliu: calls 100
+*** FLOP *** [7s Jd 2s]
+no1beyondfan888: bets 1087
+pokeher878787: calls 1087
+winghymliu: raises 1087 to 2174
+no1beyondfan888: raises 1087 to 3261
+pokeher878787: calls 2174
+winghymliu: raises 1087 to 4348
+no1beyondfan888: raises 1087 to 5435
+pokeher878787: folds 
+winghymliu: raises 1087 to 6522
+no1beyondfan888: raises 1087 to 7609
+winghymliu: calls 882 and is all-in
+Uncalled bet (205) returned to no1beyondfan888
+*** TURN *** [7s Jd 2s] [4s]
+*** RIVER *** [7s Jd 2s 4s] [2c]
+*** SHOW DOWN ***
+no1beyondfan888: shows [Ah Jh] (two pair, Jacks and Deuces)
+winghymliu: shows [Ts Js] (a flush, Jack high)
+winghymliu collected 18162 from pot
+*** SUMMARY ***
+Total pot 19219 | Rake 1057 
+Board [7s Jd 2s 4s 2c]
+Seat 1: hellokwanny (big blind) folded before Flop
+Seat 4: pokeher878787 folded on the Flop
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit folded before Flop
+Seat 8: winghymliu (button) showed [Ts Js] and won (18162) with a flush, Jack high
+Seat 9: no1beyondfan888 (small blind) showed [Ah Jh] and lost with two pair, Jacks and Deuces
+
+
+
+PokerStars Home Game Hand #211275001785: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:55:25 WET [2020/04/03 18:55:25 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (26821 in chips) 
+Seat 4: pokeher878787 (6389 in chips) 
+Seat 5: scra88le56 (31067 in chips) 
+Seat 6: 420justblazeit (15227 in chips) 
+Seat 8: winghymliu (18162 in chips) 
+Seat 9: no1beyondfan888 (74709 in chips) 
+hellokwanny: posts small blind 50
+pokeher878787: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [5d Kh]
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: calls 100
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: checks 
+*** FLOP *** [6c 3s 9s]
+pokeher878787: checks 
+winghymliu: bets 500
+pokeher878787: folds 
+Uncalled bet (500) returned to winghymliu
+winghymliu collected 236 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 250 | Rake 14 
+Board [6c 3s 9s]
+Seat 1: hellokwanny (small blind) folded before Flop
+Seat 4: pokeher878787 (big blind) folded on the Flop
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu collected (236)
+Seat 9: no1beyondfan888 (button) folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211275030613: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:56:00 WET [2020/04/03 18:56:00 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (26771 in chips) 
+Seat 4: pokeher878787 (6289 in chips) 
+Seat 5: scra88le56 (31067 in chips) 
+Seat 6: 420justblazeit (15227 in chips) 
+Seat 8: winghymliu (18298 in chips) 
+Seat 9: no1beyondfan888 (74709 in chips) 
+pokeher878787: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [6s 9s]
+420justblazeit: raises 200 to 300
+winghymliu: calls 300
+no1beyondfan888: calls 300
+hellokwanny: folds 
+pokeher878787: calls 250
+scra88le56: calls 200
+*** FLOP *** [8s Kd 5c]
+pokeher878787: bets 708
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: folds 
+no1beyondfan888: raises 708 to 1416
+pokeher878787: calls 708
+*** TURN *** [8s Kd 5c] [5d]
+pokeher878787: bets 2047
+no1beyondfan888: raises 2047 to 4094
+pokeher878787: raises 479 to 4573 and is all-in
+no1beyondfan888: calls 479
+*** RIVER *** [8s Kd 5c 5d] [Jc]
+*** SHOW DOWN ***
+pokeher878787: shows [5s As] (three of a kind, Fives)
+no1beyondfan888: shows [Kh Jh] (two pair, Kings and Jacks)
+pokeher878787 collected 12737 from pot
+*** SUMMARY ***
+Total pot 13478 | Rake 741 
+Board [8s Kd 5c 5d Jc]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 4: pokeher878787 (small blind) showed [5s As] and won (12737) with three of a kind, Fives
+Seat 5: scra88le56 (big blind) folded on the Flop
+Seat 6: 420justblazeit folded on the Flop
+Seat 8: winghymliu folded on the Flop
+Seat 9: no1beyondfan888 showed [Kh Jh] and lost with two pair, Kings and Jacks
+
+
+
+PokerStars Home Game Hand #211275072458: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:56:49 WET [2020/04/03 18:56:49 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #4 is the button
+Seat 1: hellokwanny (26771 in chips) 
+Seat 4: pokeher878787 (12737 in chips) 
+Seat 5: scra88le56 (30767 in chips) 
+Seat 6: 420justblazeit (14927 in chips) 
+Seat 8: winghymliu (17998 in chips) 
+Seat 9: no1beyondfan888 (68420 in chips) 
+scra88le56: posts small blind 50
+420justblazeit: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [3s 8d]
+winghymliu: calls 100
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: calls 100
+scra88le56: calls 50
+420justblazeit: checks 
+*** FLOP *** [4h 6c Ac]
+scra88le56: checks 
+420justblazeit: checks 
+winghymliu: bets 500
+pokeher878787: folds 
+scra88le56: folds 
+420justblazeit: folds 
+Uncalled bet (500) returned to winghymliu
+winghymliu collected 378 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 400 | Rake 22 
+Board [4h 6c Ac]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 (button) folded on the Flop
+Seat 5: scra88le56 (small blind) folded on the Flop
+Seat 6: 420justblazeit (big blind) folded on the Flop
+Seat 8: winghymliu collected (378)
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211275102209: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:57:24 WET [2020/04/03 18:57:24 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (26771 in chips) 
+Seat 4: pokeher878787 (12637 in chips) 
+Seat 5: scra88le56 (30667 in chips) 
+Seat 6: 420justblazeit (14827 in chips) 
+Seat 8: winghymliu (18276 in chips) 
+Seat 9: no1beyondfan888 (68420 in chips) 
+420justblazeit: posts small blind 50
+winghymliu: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [3c 5c]
+no1beyondfan888: raises 100 to 200
+hellokwanny: folds 
+pokeher878787: calls 200
+scra88le56: calls 200
+420justblazeit: raises 300 to 500
+winghymliu: calls 400
+no1beyondfan888: calls 300
+pokeher878787: calls 300
+scra88le56: calls 300
+*** FLOP *** [6d 2s Ac]
+420justblazeit: bets 2362
+winghymliu: folds 
+no1beyondfan888: folds 
+pokeher878787: folds 
+scra88le56: folds 
+Uncalled bet (2362) returned to 420justblazeit
+420justblazeit collected 2362 from pot
+420justblazeit: doesn't show hand 
+*** SUMMARY ***
+Total pot 2500 | Rake 138 
+Board [6d 2s Ac]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 folded on the Flop
+Seat 5: scra88le56 (button) folded on the Flop
+Seat 6: 420justblazeit (small blind) collected (2362)
+Seat 8: winghymliu (big blind) folded on the Flop
+Seat 9: no1beyondfan888 folded on the Flop
+
+
+
+PokerStars Home Game Hand #211275144797: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:58:14 WET [2020/04/03 18:58:14 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (26771 in chips) 
+Seat 4: pokeher878787 (12137 in chips) 
+Seat 5: scra88le56 (30167 in chips) 
+Seat 6: 420justblazeit (16689 in chips) 
+Seat 8: winghymliu (17776 in chips) 
+Seat 9: no1beyondfan888 (67920 in chips) 
+winghymliu: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [9d Kd]
+hellokwanny: calls 100
+pokeher878787: raises 200 to 300
+scra88le56: folds 
+420justblazeit: calls 300
+winghymliu: raises 300 to 600
+no1beyondfan888: calls 500
+hellokwanny: folds 
+pokeher878787: calls 300
+420justblazeit: calls 300
+*** FLOP *** [2d As 6c]
+winghymliu: bets 2362
+no1beyondfan888: folds 
+pokeher878787: folds 
+420justblazeit: folds 
+Uncalled bet (2362) returned to winghymliu
+winghymliu collected 2362 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 2500 | Rake 138 
+Board [2d As 6c]
+Seat 1: hellokwanny folded before Flop
+Seat 4: pokeher878787 folded on the Flop
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit (button) folded on the Flop
+Seat 8: winghymliu (small blind) collected (2362)
+Seat 9: no1beyondfan888 (big blind) folded on the Flop
+
+
+
+PokerStars Home Game Hand #211275189325: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:59:08 WET [2020/04/03 18:59:08 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (26671 in chips) 
+Seat 4: pokeher878787 (11537 in chips) 
+Seat 5: scra88le56 (30167 in chips) 
+Seat 6: 420justblazeit (16089 in chips) 
+Seat 8: winghymliu (19538 in chips) 
+Seat 9: no1beyondfan888 (67320 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Kc 3d]
+pokeher878787: calls 100
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: raises 100 to 200
+no1beyondfan888: calls 150
+hellokwanny: folds 
+pokeher878787: calls 100
+*** FLOP *** [4s Ah 5d]
+no1beyondfan888: checks 
+pokeher878787: checks 
+winghymliu: bets 661
+no1beyondfan888: folds 
+pokeher878787: folds 
+Uncalled bet (661) returned to winghymliu
+winghymliu collected 661 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 700 | Rake 39 
+Board [4s Ah 5d]
+Seat 1: hellokwanny (big blind) folded before Flop
+Seat 4: pokeher878787 folded on the Flop
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu (button) collected (661)
+Seat 9: no1beyondfan888 (small blind) folded on the Flop
+
+
+
+PokerStars Home Game Hand #211275215493: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/03 23:59:39 WET [2020/04/03 18:59:39 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (26571 in chips) 
+Seat 4: pokeher878787 (11337 in chips) 
+Seat 5: scra88le56 (30167 in chips) 
+Seat 6: 420justblazeit (16089 in chips) 
+Seat 8: winghymliu (19999 in chips) 
+Seat 9: no1beyondfan888 (67120 in chips) 
+hellokwanny: posts small blind 50
+pokeher878787: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [6s 5s]
+scra88le56: calls 100
+420justblazeit: folds 
+winghymliu: raises 100 to 200
+no1beyondfan888: folds 
+hellokwanny: calls 150
+pokeher878787: calls 100
+scra88le56: calls 100
+*** FLOP *** [Qs Kd 8s]
+hellokwanny: checks 
+pokeher878787: checks 
+scra88le56: checks 
+winghymliu: bets 756
+hellokwanny: calls 756
+pokeher878787: folds 
+scra88le56: folds 
+*** TURN *** [Qs Kd 8s] [9c]
+hellokwanny: checks 
+winghymliu: bets 2185
+hellokwanny: calls 2185
+*** RIVER *** [Qs Kd 8s 9c] [3d]
+hellokwanny: checks 
+winghymliu: bets 6314
+hellokwanny: folds 
+Uncalled bet (6314) returned to winghymliu
+winghymliu collected 6314 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 6682 | Rake 368 
+Board [Qs Kd 8s 9c 3d]
+Seat 1: hellokwanny (small blind) folded on the River
+Seat 4: pokeher878787 (big blind) folded on the Flop
+Seat 5: scra88le56 folded on the Flop
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu collected (6314)
+Seat 9: no1beyondfan888 (button) folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211275270835: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:00:39 WET [2020/04/03 19:00:39 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (23430 in chips) 
+Seat 4: pokeher878787 (11137 in chips) 
+Seat 5: scra88le56 (29967 in chips) 
+Seat 6: 420justblazeit (16089 in chips) 
+Seat 8: winghymliu (23172 in chips) 
+Seat 9: no1beyondfan888 (67120 in chips) 
+pokeher878787: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [5s 4d]
+420justblazeit: folds 
+winghymliu: calls 100
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: raises 200 to 300
+scra88le56: calls 200
+winghymliu: calls 200
+*** FLOP *** [Qh 5d As]
+pokeher878787: bets 425
+scra88le56: folds 
+winghymliu: folds 
+Uncalled bet (425) returned to pokeher878787
+pokeher878787 collected 850 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 900 | Rake 50 
+Board [Qh 5d As]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 4: pokeher878787 (small blind) collected (850)
+Seat 5: scra88le56 (big blind) folded on the Flop
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu folded on the Flop
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211275307345: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:01:15 WET [2020/04/03 19:01:15 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #4 is the button
+Seat 1: hellokwanny (23430 in chips) 
+Seat 4: pokeher878787 (11687 in chips) 
+Seat 5: scra88le56 (29667 in chips) 
+Seat 6: 420justblazeit (16089 in chips) 
+Seat 8: winghymliu (22872 in chips) 
+Seat 9: no1beyondfan888 (67120 in chips) 
+scra88le56: posts small blind 50
+420justblazeit: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [9s 3h]
+winghymliu: raises 100 to 200
+no1beyondfan888: calls 200
+hellokwanny: folds 
+pokeher878787: calls 200
+scra88le56: calls 150
+420justblazeit: folds 
+*** FLOP *** [Qc 6c 3s]
+scra88le56: checks 
+winghymliu: checks 
+no1beyondfan888: checks 
+pokeher878787: bets 100
+scra88le56: calls 100
+winghymliu: raises 1150 to 1250
+no1beyondfan888: folds 
+pokeher878787: folds 
+scra88le56: folds 
+Uncalled bet (1150) returned to winghymliu
+winghymliu collected 1134 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 1200 | Rake 66 
+Board [Qc 6c 3s]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 (button) folded on the Flop
+Seat 5: scra88le56 (small blind) folded on the Flop
+Seat 6: 420justblazeit (big blind) folded before Flop
+Seat 8: winghymliu collected (1134)
+Seat 9: no1beyondfan888 folded on the Flop
+
+
+
+PokerStars Home Game Hand #211275351356: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:01:55 WET [2020/04/03 19:01:55 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (23430 in chips) 
+Seat 4: pokeher878787 (11387 in chips) 
+Seat 5: scra88le56 (29367 in chips) 
+Seat 6: 420justblazeit (15989 in chips) 
+Seat 8: winghymliu (23706 in chips) 
+Seat 9: no1beyondfan888 (66920 in chips) 
+420justblazeit: posts small blind 50
+winghymliu: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [4s Ac]
+no1beyondfan888: folds 
+hellokwanny: calls 100
+pokeher878787: calls 100
+scra88le56: folds 
+420justblazeit: calls 50
+winghymliu: raises 100 to 200
+hellokwanny: calls 100
+pokeher878787: calls 100
+420justblazeit: calls 100
+*** FLOP *** [Kh Kc Kd]
+420justblazeit: checks 
+winghymliu: bets 100
+hellokwanny: calls 100
+pokeher878787: folds 
+420justblazeit: calls 100
+*** TURN *** [Kh Kc Kd] [7c]
+420justblazeit: checks 
+winghymliu: bets 100
+hellokwanny: raises 300 to 400
+420justblazeit: folds 
+winghymliu: calls 300
+*** RIVER *** [Kh Kc Kd 7c] [2c]
+winghymliu: bets 100
+hellokwanny: calls 100
+*** SHOW DOWN ***
+winghymliu: shows [7s 8s] (a full house, Kings full of Sevens)
+hellokwanny: mucks hand 
+winghymliu collected 1984 from pot
+*** SUMMARY ***
+Total pot 2100 | Rake 116 
+Board [Kh Kc Kd 7c 2c]
+Seat 1: hellokwanny mucked [4s Ac]
+Seat 4: pokeher878787 folded on the Flop
+Seat 5: scra88le56 (button) folded before Flop (didn't bet)
+Seat 6: 420justblazeit (small blind) folded on the Turn
+Seat 8: winghymliu (big blind) showed [7s 8s] and won (1984) with a full house, Kings full of Sevens
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211275418171: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:02:56 WET [2020/04/03 19:02:56 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (22630 in chips) 
+Seat 4: pokeher878787 (11187 in chips) 
+Seat 5: scra88le56 (29367 in chips) 
+Seat 6: 420justblazeit (15689 in chips) 
+Seat 8: winghymliu (24890 in chips) 
+Seat 9: no1beyondfan888 (66920 in chips) 
+winghymliu: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Jc Kh]
+hellokwanny: raises 300 to 400
+pokeher878787: folds 
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: folds 
+no1beyondfan888: calls 300
+*** FLOP *** [9c Ac 7c]
+no1beyondfan888: checks 
+hellokwanny: bets 401
+no1beyondfan888: folds 
+Uncalled bet (401) returned to hellokwanny
+hellokwanny collected 803 from pot
+hellokwanny: doesn't show hand 
+*** SUMMARY ***
+Total pot 850 | Rake 47 
+Board [9c Ac 7c]
+Seat 1: hellokwanny collected (803)
+Seat 4: pokeher878787 folded before Flop (didn't bet)
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit (button) folded before Flop (didn't bet)
+Seat 8: winghymliu (small blind) folded before Flop
+Seat 9: no1beyondfan888 (big blind) folded on the Flop
+
+
+
+PokerStars Home Game Hand #211275446592: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:03:22 WET [2020/04/03 19:03:22 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (23033 in chips) 
+Seat 4: pokeher878787 (11187 in chips) 
+Seat 5: scra88le56 (29367 in chips) 
+Seat 6: 420justblazeit (15689 in chips) 
+Seat 8: winghymliu (24840 in chips) 
+Seat 9: no1beyondfan888 (66520 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [6c Ts]
+pokeher878787: raises 200 to 300
+scra88le56: folds 
+420justblazeit: raises 300 to 600
+winghymliu: folds 
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: calls 300
+*** FLOP *** [Ac 4h 2h]
+pokeher878787: bets 100
+420justblazeit: raises 738 to 838
+pokeher878787: calls 738
+*** TURN *** [Ac 4h 2h] [4c]
+pokeher878787: bets 100
+420justblazeit: raises 1530 to 1630
+pokeher878787: calls 1530
+*** RIVER *** [Ac 4h 2h 4c] [5s]
+pokeher878787: bets 100
+420justblazeit: calls 100
+*** SHOW DOWN ***
+pokeher878787: shows [Td As] (two pair, Aces and Fours)
+420justblazeit: mucks hand 
+pokeher878787 collected 6129 from pot
+*** SUMMARY ***
+Total pot 6486 | Rake 357 
+Board [Ac 4h 2h 4c 5s]
+Seat 1: hellokwanny (big blind) folded before Flop
+Seat 4: pokeher878787 showed [Td As] and won (6129) with two pair, Aces and Fours
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit mucked [Qs Qc]
+Seat 8: winghymliu (button) folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 (small blind) folded before Flop
+
+
+
+PokerStars Home Game Hand #211275547720: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:04:45 WET [2020/04/03 19:04:45 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (22933 in chips) 
+Seat 4: pokeher878787 (14148 in chips) 
+Seat 5: scra88le56 (29367 in chips) 
+Seat 6: 420justblazeit (12521 in chips) 
+Seat 8: winghymliu (24840 in chips) 
+Seat 9: no1beyondfan888 (66470 in chips) 
+hellokwanny: posts small blind 50
+pokeher878787: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Js 3h]
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: folds 
+no1beyondfan888: raises 100 to 200
+hellokwanny: folds 
+pokeher878787: calls 100
+*** FLOP *** [Kd 7d Kc]
+pokeher878787: checks 
+no1beyondfan888: bets 212
+pokeher878787: folds 
+Uncalled bet (212) returned to no1beyondfan888
+no1beyondfan888 collected 425 from pot
+no1beyondfan888: doesn't show hand 
+*** SUMMARY ***
+Total pot 450 | Rake 25 
+Board [Kd 7d Kc]
+Seat 1: hellokwanny (small blind) folded before Flop
+Seat 4: pokeher878787 (big blind) folded on the Flop
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 (button) collected (425)
+
+
+
+PokerStars Home Game Hand #211275576859: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:05:11 WET [2020/04/03 19:05:11 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (22883 in chips) 
+Seat 4: pokeher878787 (13948 in chips) 
+Seat 5: scra88le56 (29367 in chips) 
+Seat 6: 420justblazeit (12521 in chips) 
+Seat 8: winghymliu (24840 in chips) 
+Seat 9: no1beyondfan888 (66695 in chips) 
+pokeher878787: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [7h Kh]
+420justblazeit: folds 
+winghymliu: calls 100
+no1beyondfan888: calls 100
+hellokwanny: folds 
+pokeher878787: raises 200 to 300
+scra88le56: calls 200
+winghymliu: calls 200
+no1beyondfan888: calls 200
+*** FLOP *** [3s Jd 8h]
+pokeher878787: bets 100
+scra88le56: folds 
+winghymliu: calls 100
+no1beyondfan888: calls 100
+*** TURN *** [3s Jd 8h] [5d]
+pokeher878787: bets 100
+winghymliu: raises 1617 to 1717
+no1beyondfan888: folds 
+pokeher878787: folds 
+Uncalled bet (1617) returned to winghymliu
+winghymliu collected 1606 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 1700 | Rake 94 
+Board [3s Jd 8h 5d]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 4: pokeher878787 (small blind) folded on the Turn
+Seat 5: scra88le56 (big blind) folded on the Flop
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu collected (1606)
+Seat 9: no1beyondfan888 folded on the Turn
+
+
+
+PokerStars Home Game Hand #211275636434: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:06:05 WET [2020/04/03 19:06:05 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #4 is the button
+Seat 1: hellokwanny (22883 in chips) 
+Seat 4: pokeher878787 (13448 in chips) 
+Seat 5: scra88le56 (29067 in chips) 
+Seat 6: 420justblazeit (12521 in chips) 
+Seat 8: winghymliu (25946 in chips) 
+Seat 9: no1beyondfan888 (66295 in chips) 
+scra88le56: posts small blind 50
+420justblazeit: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [9h Kc]
+winghymliu: calls 100
+no1beyondfan888: raises 100 to 200
+hellokwanny: folds 
+pokeher878787: raises 100 to 300
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: calls 200
+no1beyondfan888: raises 100 to 400
+pokeher878787: calls 100
+winghymliu: calls 100
+*** FLOP *** [7d Ts 9d]
+winghymliu: bets 100
+no1beyondfan888: raises 100 to 200
+pokeher878787: raises 100 to 300
+winghymliu: folds 
+no1beyondfan888: raises 100 to 400
+pokeher878787: calls 100
+*** TURN *** [7d Ts 9d] [5d]
+no1beyondfan888: checks 
+pokeher878787: bets 100
+no1beyondfan888: raises 100 to 200
+pokeher878787: raises 100 to 300
+no1beyondfan888: calls 100
+*** RIVER *** [7d Ts 9d 5d] [5h]
+no1beyondfan888: checks 
+pokeher878787: bets 12348 and is all-in
+no1beyondfan888 has timed out
+no1beyondfan888: folds 
+Uncalled bet (12348) returned to pokeher878787
+pokeher878787 collected 2693 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 2850 | Rake 157 
+Board [7d Ts 9d 5d 5h]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 (button) collected (2693)
+Seat 5: scra88le56 (small blind) folded before Flop
+Seat 6: 420justblazeit (big blind) folded before Flop
+Seat 8: winghymliu folded on the Flop
+Seat 9: no1beyondfan888 folded on the River
+
+
+
+PokerStars Home Game Hand #211275740837: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:07:35 WET [2020/04/03 19:07:35 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (22883 in chips) 
+Seat 4: pokeher878787 (15041 in chips) 
+Seat 5: scra88le56 (29017 in chips) 
+Seat 6: 420justblazeit (12421 in chips) 
+Seat 8: winghymliu (25446 in chips) 
+Seat 9: no1beyondfan888 (65195 in chips) 
+420justblazeit: posts small blind 50
+winghymliu: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [3d 6c]
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: raises 200 to 300
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: calls 200
+*** FLOP *** [Td Ks 3s]
+winghymliu: bets 614
+pokeher878787: calls 614
+*** TURN *** [Td Ks 3s] [2s]
+winghymliu: bets 1775
+pokeher878787: raises 1775 to 3550
+winghymliu: calls 1775
+*** RIVER *** [Td Ks 3s 2s] [9h]
+winghymliu: bets 100
+pokeher878787: raises 4342 to 4442
+winghymliu: calls 4342
+*** SHOW DOWN ***
+pokeher878787: shows [Tc Jh] (a pair of Tens)
+winghymliu: shows [As Kc] (a pair of Kings)
+winghymliu collected 16880 from pot
+*** SUMMARY ***
+Total pot 17862 | Rake 982 
+Board [Td Ks 3s 2s 9h]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 showed [Tc Jh] and lost with a pair of Tens
+Seat 5: scra88le56 (button) folded before Flop (didn't bet)
+Seat 6: 420justblazeit (small blind) folded before Flop
+Seat 8: winghymliu (big blind) showed [As Kc] and won (16880) with a pair of Kings
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211275818169: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:08:46 WET [2020/04/03 19:08:46 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (22883 in chips) 
+Seat 4: pokeher878787 (6135 in chips) 
+Seat 5: scra88le56 (29017 in chips) 
+Seat 6: 420justblazeit (12371 in chips) 
+Seat 8: winghymliu (33420 in chips) 
+Seat 9: no1beyondfan888 (65195 in chips) 
+winghymliu: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Td Kh]
+hellokwanny: raises 300 to 400
+pokeher878787: folds 
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: folds 
+no1beyondfan888: folds 
+Uncalled bet (300) returned to hellokwanny
+hellokwanny collected 250 from pot
+hellokwanny: doesn't show hand 
+*** SUMMARY ***
+Total pot 250 | Rake 0 
+Seat 1: hellokwanny collected (250)
+Seat 4: pokeher878787 folded before Flop (didn't bet)
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit (button) folded before Flop (didn't bet)
+Seat 8: winghymliu (small blind) folded before Flop
+Seat 9: no1beyondfan888 (big blind) folded before Flop
+
+
+
+PokerStars Home Game Hand #211275848677: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:09:14 WET [2020/04/03 19:09:14 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (23033 in chips) 
+Seat 4: pokeher878787 (6135 in chips) 
+Seat 5: scra88le56 (29017 in chips) 
+Seat 6: 420justblazeit (12371 in chips) 
+Seat 8: winghymliu (33370 in chips) 
+Seat 9: no1beyondfan888 (65095 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [7h 9s]
+pokeher878787: raises 200 to 300
+scra88le56: folds 
+420justblazeit: calls 300
+winghymliu: raises 1050 to 1350
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: raises 1050 to 2400
+420justblazeit: folds 
+winghymliu: folds 
+Uncalled bet (1050) returned to pokeher878787
+pokeher878787 collected 3150 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 3150 | Rake 0 
+Seat 1: hellokwanny (big blind) folded before Flop
+Seat 4: pokeher878787 collected (3150)
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit folded before Flop
+Seat 8: winghymliu (button) folded before Flop
+Seat 9: no1beyondfan888 (small blind) folded before Flop
+
+
+
+PokerStars Home Game Hand #211275892257: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:09:55 WET [2020/04/03 19:09:55 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (22933 in chips) 
+Seat 4: pokeher878787 (7935 in chips) 
+Seat 5: scra88le56 (29017 in chips) 
+Seat 6: 420justblazeit (12071 in chips) 
+Seat 8: winghymliu (32020 in chips) 
+Seat 9: no1beyondfan888 (65045 in chips) 
+hellokwanny: posts small blind 50
+pokeher878787: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Js 3d]
+scra88le56: calls 100
+420justblazeit: folds 
+winghymliu: raises 100 to 200
+no1beyondfan888: raises 100 to 300
+hellokwanny: folds 
+pokeher878787: calls 200
+scra88le56: calls 200
+winghymliu: raises 100 to 400
+no1beyondfan888: calls 100
+pokeher878787: calls 100
+scra88le56: calls 100
+*** FLOP *** [6s Tc Qh]
+pokeher878787: checks 
+scra88le56: checks 
+winghymliu: checks 
+no1beyondfan888: bets 1559
+pokeher878787: folds 
+scra88le56: folds 
+winghymliu: folds 
+Uncalled bet (1559) returned to no1beyondfan888
+no1beyondfan888 collected 1559 from pot
+no1beyondfan888: doesn't show hand 
+*** SUMMARY ***
+Total pot 1650 | Rake 91 
+Board [6s Tc Qh]
+Seat 1: hellokwanny (small blind) folded before Flop
+Seat 4: pokeher878787 (big blind) folded on the Flop
+Seat 5: scra88le56 folded on the Flop
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu folded on the Flop
+Seat 9: no1beyondfan888 (button) collected (1559)
+
+
+
+PokerStars Home Game Hand #211275944373: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:10:43 WET [2020/04/03 19:10:43 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (22883 in chips) 
+Seat 4: pokeher878787 (7535 in chips) 
+Seat 5: scra88le56 (28617 in chips) 
+Seat 6: 420justblazeit (12071 in chips) 
+Seat 8: winghymliu (31620 in chips) 
+Seat 9: no1beyondfan888 (66204 in chips) 
+pokeher878787: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [6h 3h]
+420justblazeit: folds 
+winghymliu: folds 
+no1beyondfan888: calls 100
+hellokwanny: folds 
+pokeher878787: calls 50
+scra88le56: checks 
+*** FLOP *** [5d 9s 4c]
+pokeher878787: checks 
+scra88le56: bets 100
+no1beyondfan888: calls 100
+pokeher878787: calls 100
+*** TURN *** [5d 9s 4c] [9h]
+pokeher878787: checks 
+scra88le56: bets 567
+no1beyondfan888: calls 567
+pokeher878787: folds 
+*** RIVER *** [5d 9s 4c 9h] [8h]
+scra88le56: checks 
+no1beyondfan888: bets 1639
+scra88le56: folds 
+Uncalled bet (1639) returned to no1beyondfan888
+no1beyondfan888 collected 1639 from pot
+no1beyondfan888: doesn't show hand 
+*** SUMMARY ***
+Total pot 1734 | Rake 95 
+Board [5d 9s 4c 9h 8h]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 4: pokeher878787 (small blind) folded on the Turn
+Seat 5: scra88le56 (big blind) folded on the River
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 collected (1639)
+
+
+
+PokerStars Home Game Hand #211275989445: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:11:25 WET [2020/04/03 19:11:25 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #4 is the button
+Seat 1: hellokwanny (22883 in chips) 
+Seat 4: pokeher878787 (7335 in chips) 
+Seat 5: scra88le56 (27850 in chips) 
+Seat 6: 420justblazeit (12071 in chips) 
+Seat 8: winghymliu (31620 in chips) 
+Seat 9: no1beyondfan888 (67076 in chips) 
+scra88le56: posts small blind 50
+420justblazeit: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Ad 9h]
+winghymliu: raises 100 to 200
+no1beyondfan888: calls 200
+hellokwanny: calls 200
+pokeher878787: folds 
+scra88le56: folds 
+420justblazeit: folds 
+*** FLOP *** [6h Jc Qc]
+winghymliu: bets 709
+no1beyondfan888: folds 
+hellokwanny: folds 
+Uncalled bet (709) returned to winghymliu
+winghymliu collected 709 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 750 | Rake 41 
+Board [6h Jc Qc]
+Seat 1: hellokwanny folded on the Flop
+Seat 4: pokeher878787 (button) folded before Flop (didn't bet)
+Seat 5: scra88le56 (small blind) folded before Flop
+Seat 6: 420justblazeit (big blind) folded before Flop
+Seat 8: winghymliu collected (709)
+Seat 9: no1beyondfan888 folded on the Flop
+
+
+
+PokerStars Home Game Hand #211276028826: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:12:02 WET [2020/04/03 19:12:02 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (22683 in chips) 
+Seat 4: pokeher878787 (7335 in chips) 
+Seat 5: scra88le56 (27800 in chips) 
+Seat 6: 420justblazeit (11971 in chips) 
+Seat 8: winghymliu (32129 in chips) 
+Seat 9: no1beyondfan888 (66876 in chips) 
+420justblazeit: posts small blind 50
+winghymliu: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Th 7h]
+no1beyondfan888: folds 
+hellokwanny: calls 100
+pokeher878787: calls 100
+scra88le56: folds 
+420justblazeit: calls 50
+winghymliu: checks 
+*** FLOP *** [Js Jc Tc]
+420justblazeit: checks 
+winghymliu: checks 
+hellokwanny: bets 200
+pokeher878787: folds 
+420justblazeit: folds 
+winghymliu: folds 
+Uncalled bet (200) returned to hellokwanny
+hellokwanny collected 378 from pot
+hellokwanny: doesn't show hand 
+*** SUMMARY ***
+Total pot 400 | Rake 22 
+Board [Js Jc Tc]
+Seat 1: hellokwanny collected (378)
+Seat 4: pokeher878787 folded on the Flop
+Seat 5: scra88le56 (button) folded before Flop (didn't bet)
+Seat 6: 420justblazeit (small blind) folded on the Flop
+Seat 8: winghymliu (big blind) folded on the Flop
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211276059949: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:12:31 WET [2020/04/03 19:12:31 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (22961 in chips) 
+Seat 4: pokeher878787 (7235 in chips) 
+Seat 5: scra88le56 (27800 in chips) 
+Seat 6: 420justblazeit (11871 in chips) 
+Seat 8: winghymliu (32029 in chips) 
+winghymliu: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [2d 3c]
+pokeher878787: calls 100
+scra88le56: raises 400 to 500
+420justblazeit: folds 
+winghymliu: folds 
+hellokwanny: folds 
+pokeher878787: folds 
+Uncalled bet (400) returned to scra88le56
+scra88le56 collected 350 from pot
+scra88le56: doesn't show hand 
+*** SUMMARY ***
+Total pot 350 | Rake 0 
+Seat 1: hellokwanny (big blind) folded before Flop
+Seat 4: pokeher878787 folded before Flop
+Seat 5: scra88le56 collected (350)
+Seat 6: 420justblazeit (button) folded before Flop (didn't bet)
+Seat 8: winghymliu (small blind) folded before Flop
+
+
+
+PokerStars Home Game Hand #211276074315: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:12:45 WET [2020/04/03 19:12:45 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (22861 in chips) 
+Seat 4: pokeher878787 (7135 in chips) 
+Seat 5: scra88le56 (28050 in chips) 
+Seat 6: 420justblazeit (11871 in chips) 
+Seat 8: winghymliu (31979 in chips) 
+hellokwanny: posts small blind 50
+pokeher878787: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [9s Kh]
+scra88le56: calls 100
+420justblazeit: folds 
+winghymliu: calls 100
+hellokwanny: folds 
+pokeher878787: checks 
+*** FLOP *** [Ah Js 9d]
+pokeher878787: checks 
+scra88le56: bets 200
+winghymliu: folds 
+pokeher878787: folds 
+Uncalled bet (200) returned to scra88le56
+scra88le56 collected 331 from pot
+scra88le56: doesn't show hand 
+*** SUMMARY ***
+Total pot 350 | Rake 19 
+Board [Ah Js 9d]
+Seat 1: hellokwanny (small blind) folded before Flop
+Seat 4: pokeher878787 (big blind) folded on the Flop
+Seat 5: scra88le56 collected (331)
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu (button) folded on the Flop
+
+
+
+PokerStars Home Game Hand #211276102628: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:13:12 WET [2020/04/03 19:13:12 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (22811 in chips) 
+Seat 4: pokeher878787 (7035 in chips) 
+Seat 5: scra88le56 (28281 in chips) 
+Seat 6: 420justblazeit (11871 in chips) 
+Seat 8: winghymliu (31879 in chips) 
+Seat 9: no1beyondfan888 (66876 in chips) 
+pokeher878787: posts small blind 50
+scra88le56: posts big blind 100
+no1beyondfan888: posts small & big blinds 150
+*** HOLE CARDS ***
+Dealt to hellokwanny [Qd 3d]
+420justblazeit: raises 700 to 800
+winghymliu: folds 
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: calls 750
+scra88le56: folds 
+*** FLOP *** [5h 7c 2c]
+pokeher878787: bets 874
+420justblazeit: raises 3496 to 4370
+pokeher878787: raises 1865 to 6235 and is all-in
+420justblazeit: calls 1865
+*** TURN *** [5h 7c 2c] [4d]
+*** RIVER *** [5h 7c 2c 4d] [Jh]
+*** SHOW DOWN ***
+pokeher878787: shows [5d Ah] (a pair of Fives)
+420justblazeit: shows [Ac Kd] (high card Ace)
+pokeher878787 collected 13532 from pot
+*** SUMMARY ***
+Total pot 14320 | Rake 788 
+Board [5h 7c 2c 4d Jh]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 4: pokeher878787 (small blind) showed [5d Ah] and won (13532) with a pair of Fives
+Seat 5: scra88le56 (big blind) folded before Flop
+Seat 6: 420justblazeit showed [Ac Kd] and lost with high card Ace
+Seat 8: winghymliu folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211276177277: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:14:22 WET [2020/04/03 19:14:22 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #4 is the button
+Seat 1: hellokwanny (22811 in chips) 
+Seat 4: pokeher878787 (13532 in chips) 
+Seat 5: scra88le56 (28181 in chips) 
+Seat 6: 420justblazeit (4836 in chips) 
+Seat 8: winghymliu (31879 in chips) 
+Seat 9: no1beyondfan888 (66726 in chips) 
+scra88le56: posts small blind 50
+420justblazeit: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [4d Qs]
+winghymliu: raises 300 to 400
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: folds 
+scra88le56: folds 
+420justblazeit: folds 
+Uncalled bet (300) returned to winghymliu
+winghymliu collected 250 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 250 | Rake 0 
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 (button) folded before Flop (didn't bet)
+Seat 5: scra88le56 (small blind) folded before Flop
+Seat 6: 420justblazeit (big blind) folded before Flop
+Seat 8: winghymliu collected (250)
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211276202568: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:14:46 WET [2020/04/03 19:14:46 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (22811 in chips) 
+Seat 4: pokeher878787 (13532 in chips) 
+Seat 5: scra88le56 (28131 in chips) 
+Seat 6: 420justblazeit (4736 in chips) 
+Seat 8: winghymliu (32029 in chips) 
+Seat 9: no1beyondfan888 (66726 in chips) 
+420justblazeit: posts small blind 50
+winghymliu: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [4c 5c]
+no1beyondfan888: folds 
+hellokwanny: raises 200 to 300
+pokeher878787: calls 300
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: folds 
+*** FLOP *** [6s 5h 7d]
+hellokwanny: bets 354
+pokeher878787: raises 354 to 708
+hellokwanny: calls 354
+*** TURN *** [6s 5h 7d] [Ac]
+hellokwanny: checks 
+pokeher878787: bets 2047
+hellokwanny: folds 
+Uncalled bet (2047) returned to pokeher878787
+pokeher878787 collected 2047 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 2166 | Rake 119 
+Board [6s 5h 7d Ac]
+Seat 1: hellokwanny folded on the Turn
+Seat 4: pokeher878787 collected (2047)
+Seat 5: scra88le56 (button) folded before Flop (didn't bet)
+Seat 6: 420justblazeit (small blind) folded before Flop
+Seat 8: winghymliu (big blind) folded before Flop
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211276245979: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:15:27 WET [2020/04/03 19:15:27 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (21803 in chips) 
+Seat 4: pokeher878787 (14571 in chips) 
+Seat 5: scra88le56 (28131 in chips) 
+Seat 6: 420justblazeit (4686 in chips) 
+Seat 8: winghymliu (31929 in chips) 
+Seat 9: no1beyondfan888 (66726 in chips) 
+winghymliu: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [7d 7s]
+hellokwanny: raises 200 to 300
+pokeher878787: folds 
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: folds 
+no1beyondfan888: folds 
+Uncalled bet (200) returned to hellokwanny
+hellokwanny collected 250 from pot
+hellokwanny: doesn't show hand 
+*** SUMMARY ***
+Total pot 250 | Rake 0 
+Seat 1: hellokwanny collected (250)
+Seat 4: pokeher878787 folded before Flop (didn't bet)
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit (button) folded before Flop (didn't bet)
+Seat 8: winghymliu (small blind) folded before Flop
+Seat 9: no1beyondfan888 (big blind) folded before Flop
+
+
+
+PokerStars Home Game Hand #211276261210: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:15:38 WET [2020/04/03 19:15:38 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (21953 in chips) 
+Seat 4: pokeher878787 (14571 in chips) 
+Seat 5: scra88le56 (28131 in chips) 
+Seat 6: 420justblazeit (4686 in chips) 
+Seat 8: winghymliu (31879 in chips) 
+Seat 9: no1beyondfan888 (66626 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [As 4c]
+pokeher878787: calls 100
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: calls 100
+no1beyondfan888: folds 
+hellokwanny: checks 
+*** FLOP *** [Kc Qs Kd]
+hellokwanny: checks 
+pokeher878787: bets 100
+winghymliu: raises 531 to 631
+hellokwanny: folds 
+pokeher878787: folds 
+Uncalled bet (531) returned to winghymliu
+winghymliu collected 520 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 550 | Rake 30 
+Board [Kc Qs Kd]
+Seat 1: hellokwanny (big blind) folded on the Flop
+Seat 4: pokeher878787 folded on the Flop
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu (button) collected (520)
+Seat 9: no1beyondfan888 (small blind) folded before Flop
+
+
+
+PokerStars Home Game Hand #211276285910: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:16:02 WET [2020/04/03 19:16:02 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (21853 in chips) 
+Seat 4: pokeher878787 (14371 in chips) 
+Seat 5: scra88le56 (28131 in chips) 
+Seat 6: 420justblazeit (4686 in chips) 
+Seat 8: winghymliu (32199 in chips) 
+Seat 9: no1beyondfan888 (66576 in chips) 
+hellokwanny: posts small blind 50
+pokeher878787: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Kc 2d]
+scra88le56: calls 100
+420justblazeit: folds 
+winghymliu: raises 100 to 200
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: calls 100
+scra88le56: calls 100
+*** FLOP *** [5d 8h 9c]
+pokeher878787: bets 614
+scra88le56: folds 
+winghymliu: folds 
+Uncalled bet (614) returned to pokeher878787
+pokeher878787 collected 614 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 650 | Rake 36 
+Board [5d 8h 9c]
+Seat 1: hellokwanny (small blind) folded before Flop
+Seat 4: pokeher878787 (big blind) collected (614)
+Seat 5: scra88le56 folded on the Flop
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu folded on the Flop
+Seat 9: no1beyondfan888 (button) folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211276308954: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:16:24 WET [2020/04/03 19:16:24 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (21803 in chips) 
+Seat 4: pokeher878787 (14785 in chips) 
+Seat 5: scra88le56 (27931 in chips) 
+Seat 6: 420justblazeit (4686 in chips) 
+Seat 8: winghymliu (31999 in chips) 
+Seat 9: no1beyondfan888 (66576 in chips) 
+pokeher878787: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Js 7d]
+420justblazeit: folds 
+winghymliu: raises 100 to 200
+no1beyondfan888: calls 200
+hellokwanny: folds 
+pokeher878787: calls 150
+scra88le56: calls 100
+*** FLOP *** [Qd Qh 5d]
+pokeher878787: bets 100
+scra88le56: folds 
+winghymliu: folds 
+no1beyondfan888: calls 100
+*** TURN *** [Qd Qh 5d] [Kd]
+pokeher878787: bets 100
+no1beyondfan888: raises 100 to 200
+pokeher878787: raises 1345 to 1545
+no1beyondfan888: calls 1345
+*** RIVER *** [Qd Qh 5d Kd] [9d]
+pokeher878787: bets 12940 and is all-in
+no1beyondfan888: folds 
+Uncalled bet (12940) returned to pokeher878787
+pokeher878787 collected 3865 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 4090 | Rake 225 
+Board [Qd Qh 5d Kd 9d]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 4: pokeher878787 (small blind) collected (3865)
+Seat 5: scra88le56 (big blind) folded on the Flop
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu folded on the Flop
+Seat 9: no1beyondfan888 folded on the River
+
+
+
+PokerStars Home Game Hand #211276375694: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:17:27 WET [2020/04/03 19:17:27 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #4 is the button
+Seat 1: hellokwanny (21803 in chips) 
+Seat 4: pokeher878787 (16805 in chips) 
+Seat 5: scra88le56 (27731 in chips) 
+Seat 6: 420justblazeit (4686 in chips) 
+Seat 8: winghymliu (31799 in chips) 
+Seat 9: no1beyondfan888 (64731 in chips) 
+scra88le56: posts small blind 50
+420justblazeit: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [5c 2d]
+winghymliu: folds 
+no1beyondfan888: calls 100
+hellokwanny: folds 
+pokeher878787: raises 200 to 300
+scra88le56: raises 500 to 800
+420justblazeit: folds 
+no1beyondfan888: calls 700
+pokeher878787: calls 500
+*** FLOP *** [7d 8d 9h]
+scra88le56: bets 1181
+no1beyondfan888: folds 
+pokeher878787: folds 
+Uncalled bet (1181) returned to scra88le56
+scra88le56 collected 2362 from pot
+scra88le56: doesn't show hand 
+*** SUMMARY ***
+Total pot 2500 | Rake 138 
+Board [7d 8d 9h]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 (button) folded on the Flop
+Seat 5: scra88le56 (small blind) collected (2362)
+Seat 6: 420justblazeit (big blind) folded before Flop
+Seat 8: winghymliu folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 folded on the Flop
+
+
+
+PokerStars Home Game Hand #211276427881: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:18:17 WET [2020/04/03 19:18:17 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (21803 in chips) 
+Seat 4: pokeher878787 (16005 in chips) 
+Seat 5: scra88le56 (29293 in chips) 
+Seat 6: 420justblazeit (4586 in chips) 
+Seat 8: winghymliu (31799 in chips) 
+Seat 9: no1beyondfan888 (63931 in chips) 
+420justblazeit: posts small blind 50
+winghymliu: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [7h Qc]
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: calls 100
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: raises 250 to 350
+pokeher878787: folds 
+Uncalled bet (250) returned to winghymliu
+winghymliu collected 250 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 250 | Rake 0 
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 folded before Flop
+Seat 5: scra88le56 (button) folded before Flop (didn't bet)
+Seat 6: 420justblazeit (small blind) folded before Flop
+Seat 8: winghymliu (big blind) collected (250)
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211276448686: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:18:37 WET [2020/04/03 19:18:37 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (21803 in chips) 
+Seat 4: pokeher878787 (15905 in chips) 
+Seat 5: scra88le56 (29293 in chips) 
+Seat 6: 420justblazeit (4536 in chips) 
+Seat 8: winghymliu (31949 in chips) 
+Seat 9: no1beyondfan888 (63931 in chips) 
+winghymliu: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Qs 4h]
+hellokwanny: folds 
+pokeher878787: calls 100
+scra88le56: folds 
+420justblazeit: folds 
+winghymliu: raises 300 to 400
+no1beyondfan888: calls 300
+pokeher878787: folds 
+*** FLOP *** [9h 9c 2c]
+winghymliu: bets 850
+no1beyondfan888: folds 
+Uncalled bet (850) returned to winghymliu
+winghymliu collected 850 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 900 | Rake 50 
+Board [9h 9c 2c]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 folded before Flop
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit (button) folded before Flop (didn't bet)
+Seat 8: winghymliu (small blind) collected (850)
+Seat 9: no1beyondfan888 (big blind) folded on the Flop
+
+
+
+PokerStars Home Game Hand #211276472373: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:19:00 WET [2020/04/03 19:19:00 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (21803 in chips) 
+Seat 4: pokeher878787 (15805 in chips) 
+Seat 5: scra88le56 (29293 in chips) 
+Seat 6: 420justblazeit (4536 in chips) 
+Seat 8: winghymliu (32399 in chips) 
+Seat 9: no1beyondfan888 (63531 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [3c 2c]
+pokeher878787: calls 100
+scra88le56: raises 200 to 300
+420justblazeit: calls 300
+winghymliu: calls 300
+no1beyondfan888: calls 250
+hellokwanny: calls 200
+pokeher878787: calls 200
+*** FLOP *** [Qd 7d 7c]
+no1beyondfan888: checks 
+hellokwanny: checks 
+pokeher878787: checks 
+scra88le56: bets 850
+420justblazeit: folds 
+winghymliu: folds 
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: folds 
+Uncalled bet (850) returned to scra88le56
+scra88le56 collected 1701 from pot
+scra88le56: doesn't show hand 
+*** SUMMARY ***
+Total pot 1800 | Rake 99 
+Board [Qd 7d 7c]
+Seat 1: hellokwanny (big blind) folded on the Flop
+Seat 4: pokeher878787 folded on the Flop
+Seat 5: scra88le56 collected (1701)
+Seat 6: 420justblazeit folded on the Flop
+Seat 8: winghymliu (button) folded on the Flop
+Seat 9: no1beyondfan888 (small blind) folded on the Flop
+
+
+
+PokerStars Home Game Hand #211276505433: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:19:32 WET [2020/04/03 19:19:32 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (21503 in chips) 
+Seat 4: pokeher878787 (15505 in chips) 
+Seat 5: scra88le56 (30694 in chips) 
+Seat 6: 420justblazeit (4236 in chips) 
+Seat 8: winghymliu (32099 in chips) 
+Seat 9: no1beyondfan888 (63231 in chips) 
+hellokwanny: posts small blind 50
+pokeher878787: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Jc 8c]
+scra88le56: raises 100 to 200
+420justblazeit: folds 
+winghymliu: folds 
+no1beyondfan888: folds 
+hellokwanny: calls 150
+pokeher878787: calls 100
+*** FLOP *** [Th Ad Kh]
+hellokwanny: checks 
+pokeher878787: bets 100
+scra88le56: raises 383 to 483
+hellokwanny: folds 
+pokeher878787: calls 383
+*** TURN *** [Th Ad Kh] [5c]
+pokeher878787: bets 100
+scra88le56: raises 100 to 200
+pokeher878787: calls 100
+*** RIVER *** [Th Ad Kh 5c] [Ah]
+pokeher878787: checks 
+scra88le56: bets 929
+pokeher878787: folds 
+Uncalled bet (929) returned to scra88le56
+scra88le56 collected 1858 from pot
+scra88le56: doesn't show hand 
+*** SUMMARY ***
+Total pot 1966 | Rake 108 
+Board [Th Ad Kh 5c Ah]
+Seat 1: hellokwanny (small blind) folded on the Flop
+Seat 4: pokeher878787 (big blind) folded on the River
+Seat 5: scra88le56 collected (1858)
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 (button) folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211276561339: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:20:24 WET [2020/04/03 19:20:24 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (21303 in chips) 
+Seat 4: pokeher878787 (14622 in chips) 
+Seat 5: scra88le56 (31669 in chips) 
+Seat 6: 420justblazeit (4236 in chips) 
+Seat 8: winghymliu (32099 in chips) 
+Seat 9: no1beyondfan888 (63231 in chips) 
+pokeher878787: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [7c 4h]
+420justblazeit: raises 300 to 400
+winghymliu: folds 
+no1beyondfan888: calls 400
+hellokwanny: folds 
+pokeher878787: folds 
+scra88le56: calls 300
+*** FLOP *** [3d 9h 3s]
+scra88le56: checks 
+420justblazeit: checks 
+no1beyondfan888: bets 1181
+scra88le56: folds 
+420justblazeit: folds 
+Uncalled bet (1181) returned to no1beyondfan888
+no1beyondfan888 collected 1181 from pot
+no1beyondfan888: doesn't show hand 
+*** SUMMARY ***
+Total pot 1250 | Rake 69 
+Board [3d 9h 3s]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 4: pokeher878787 (small blind) folded before Flop
+Seat 5: scra88le56 (big blind) folded on the Flop
+Seat 6: 420justblazeit folded on the Flop
+Seat 8: winghymliu folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 collected (1181)
+
+
+
+PokerStars Home Game Hand #211276596148: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:20:57 WET [2020/04/03 19:20:57 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #4 is the button
+Seat 1: hellokwanny (21303 in chips) 
+Seat 4: pokeher878787 (14572 in chips) 
+Seat 5: scra88le56 (31269 in chips) 
+Seat 6: 420justblazeit (3836 in chips) 
+Seat 8: winghymliu (32099 in chips) 
+Seat 9: no1beyondfan888 (64012 in chips) 
+scra88le56: posts small blind 50
+420justblazeit: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [7s 6h]
+winghymliu: raises 250 to 350
+no1beyondfan888: folds 
+hellokwanny has timed out
+hellokwanny: folds 
+pokeher878787: folds 
+scra88le56: folds 
+420justblazeit: folds 
+Uncalled bet (250) returned to winghymliu
+winghymliu collected 250 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 250 | Rake 0 
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 (button) folded before Flop (didn't bet)
+Seat 5: scra88le56 (small blind) folded before Flop
+Seat 6: 420justblazeit (big blind) folded before Flop
+Seat 8: winghymliu collected (250)
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211276626332: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:21:26 WET [2020/04/03 19:21:26 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (21303 in chips) 
+Seat 4: pokeher878787 (14572 in chips) 
+Seat 5: scra88le56 (31219 in chips) 
+Seat 6: 420justblazeit (3736 in chips) 
+Seat 8: winghymliu (32249 in chips) 
+Seat 9: no1beyondfan888 (64012 in chips) 
+420justblazeit: posts small blind 50
+winghymliu: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Qs Kc]
+no1beyondfan888: folds 
+hellokwanny: raises 300 to 400
+pokeher878787: calls 400
+scra88le56: calls 400
+420justblazeit: folds 
+winghymliu: folds 
+*** FLOP *** [8s 7s As]
+hellokwanny: checks 
+pokeher878787: bets 638
+scra88le56: calls 638
+hellokwanny: calls 638
+*** TURN *** [8s 7s As] [3d]
+hellokwanny: checks 
+pokeher878787: bets 100
+scra88le56: calls 100
+hellokwanny: calls 100
+*** RIVER *** [8s 7s As 3d] [Td]
+hellokwanny: bets 1684
+pokeher878787: folds 
+scra88le56: calls 1684
+*** SHOW DOWN ***
+hellokwanny: shows [Qs Kc] (high card Ace)
+scra88le56: shows [Jc Ts] (a pair of Tens)
+scra88le56 collected 6551 from pot
+*** SUMMARY ***
+Total pot 6932 | Rake 381 
+Board [8s 7s As 3d Td]
+Seat 1: hellokwanny showed [Qs Kc] and lost with high card Ace
+Seat 4: pokeher878787 folded on the River
+Seat 5: scra88le56 (button) showed [Jc Ts] and won (6551) with a pair of Tens
+Seat 6: 420justblazeit (small blind) folded before Flop
+Seat 8: winghymliu (big blind) folded before Flop
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211276669230: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:22:07 WET [2020/04/03 19:22:07 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (18481 in chips) 
+Seat 4: pokeher878787 (13434 in chips) 
+Seat 5: scra88le56 (34948 in chips) 
+Seat 6: 420justblazeit (3686 in chips) 
+Seat 8: winghymliu (32149 in chips) 
+Seat 9: no1beyondfan888 (64012 in chips) 
+winghymliu: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [8s Ks]
+hellokwanny: raises 200 to 300
+pokeher878787: calls 300
+scra88le56: calls 300
+420justblazeit: folds 
+winghymliu: calls 250
+no1beyondfan888: calls 200
+*** FLOP *** [5s 4c Td]
+winghymliu: bets 100
+no1beyondfan888: raises 100 to 200
+hellokwanny: folds 
+pokeher878787: calls 200
+scra88le56: calls 200
+winghymliu: calls 100
+*** TURN *** [5s 4c Td] [6s]
+winghymliu: bets 100
+no1beyondfan888: calls 100
+pokeher878787: calls 100
+scra88le56: calls 100
+*** RIVER *** [5s 4c Td 6s] [3h]
+winghymliu: bets 100
+no1beyondfan888: calls 100
+pokeher878787: calls 100
+scra88le56: folds 
+*** SHOW DOWN ***
+winghymliu: shows [9h Ah] (high card Ace)
+no1beyondfan888: shows [Js Jc] (a pair of Jacks)
+pokeher878787: mucks hand 
+no1beyondfan888 collected 2835 from pot
+*** SUMMARY ***
+Total pot 3000 | Rake 165 
+Board [5s 4c Td 6s 3h]
+Seat 1: hellokwanny folded on the Flop
+Seat 4: pokeher878787 mucked [5c Kc]
+Seat 5: scra88le56 folded on the River
+Seat 6: 420justblazeit (button) folded before Flop (didn't bet)
+Seat 8: winghymliu (small blind) showed [9h Ah] and lost with high card Ace
+Seat 9: no1beyondfan888 (big blind) showed [Js Jc] and won (2835) with a pair of Jacks
+
+
+
+PokerStars Home Game Hand #211276752788: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:23:20 WET [2020/04/03 19:23:20 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (18181 in chips) 
+Seat 4: pokeher878787 (12734 in chips) 
+Seat 5: scra88le56 (34348 in chips) 
+Seat 6: 420justblazeit (3686 in chips) 
+Seat 8: winghymliu (31449 in chips) 
+Seat 9: no1beyondfan888 (66147 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [4s 4d]
+pokeher878787: calls 100
+scra88le56: calls 100
+420justblazeit: folds 
+winghymliu: calls 100
+no1beyondfan888: raises 100 to 200
+hellokwanny: calls 100
+pokeher878787: calls 100
+scra88le56: calls 100
+winghymliu: calls 100
+*** FLOP *** [Th 3h Jd]
+no1beyondfan888: checks 
+hellokwanny: bets 472
+pokeher878787: folds 
+scra88le56: folds 
+winghymliu: folds 
+no1beyondfan888: calls 472
+*** TURN *** [Th 3h Jd] [Qd]
+no1beyondfan888: checks 
+hellokwanny: bets 918
+no1beyondfan888: calls 918
+*** RIVER *** [Th 3h Jd Qd] [Qh]
+no1beyondfan888: checks 
+hellokwanny: checks 
+*** SHOW DOWN ***
+no1beyondfan888: shows [9c Tc] (two pair, Queens and Tens)
+hellokwanny: mucks hand 
+no1beyondfan888 collected 3572 from pot
+*** SUMMARY ***
+Total pot 3780 | Rake 208 
+Board [Th 3h Jd Qd Qh]
+Seat 1: hellokwanny (big blind) mucked [4s 4d]
+Seat 4: pokeher878787 folded on the Flop
+Seat 5: scra88le56 folded on the Flop
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu (button) folded on the Flop
+Seat 9: no1beyondfan888 (small blind) showed [9c Tc] and won (3572) with two pair, Queens and Tens
+
+
+
+PokerStars Home Game Hand #211276819277: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:24:25 WET [2020/04/03 19:24:25 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (16591 in chips) 
+Seat 4: pokeher878787 (12534 in chips) 
+Seat 5: scra88le56 (34148 in chips) 
+Seat 6: 420justblazeit (3686 in chips) 
+Seat 8: winghymliu (31249 in chips) 
+Seat 9: no1beyondfan888 (68129 in chips) 
+hellokwanny: posts small blind 50
+pokeher878787: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [3s Qd]
+scra88le56: folds 
+420justblazeit: calls 100
+winghymliu: raises 100 to 200
+no1beyondfan888: calls 200
+hellokwanny: folds 
+pokeher878787: calls 100
+420justblazeit: calls 100
+*** FLOP *** [6h 5c 9s]
+pokeher878787: bets 100
+420justblazeit: raises 3386 to 3486 and is all-in
+winghymliu: folds 
+no1beyondfan888: folds 
+pokeher878787: folds 
+Uncalled bet (3386) returned to 420justblazeit
+420justblazeit collected 992 from pot
+420justblazeit: doesn't show hand 
+*** SUMMARY ***
+Total pot 1050 | Rake 58 
+Board [6h 5c 9s]
+Seat 1: hellokwanny (small blind) folded before Flop
+Seat 4: pokeher878787 (big blind) folded on the Flop
+Seat 5: scra88le56 folded before Flop (didn't bet)
+Seat 6: 420justblazeit collected (992)
+Seat 8: winghymliu folded on the Flop
+Seat 9: no1beyondfan888 (button) folded on the Flop
+
+
+
+PokerStars Home Game Hand #211276851941: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:24:57 WET [2020/04/03 19:24:57 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (16541 in chips) 
+Seat 4: pokeher878787 (12234 in chips) 
+Seat 5: scra88le56 (34148 in chips) 
+Seat 6: 420justblazeit (4378 in chips) 
+Seat 8: winghymliu (31049 in chips) 
+Seat 9: no1beyondfan888 (67929 in chips) 
+pokeher878787: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Jh 3s]
+420justblazeit: folds 
+winghymliu: raises 100 to 200
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: calls 150
+scra88le56: calls 100
+*** FLOP *** [Jd 9s 5c]
+pokeher878787: checks 
+scra88le56: checks 
+winghymliu: bets 567
+pokeher878787: folds 
+scra88le56: calls 567
+*** TURN *** [Jd 9s 5c] [Kc]
+scra88le56: checks 
+winghymliu: bets 1639
+scra88le56: folds 
+Uncalled bet (1639) returned to winghymliu
+winghymliu collected 1639 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 1734 | Rake 95 
+Board [Jd 9s 5c Kc]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 4: pokeher878787 (small blind) folded on the Flop
+Seat 5: scra88le56 (big blind) folded on the Turn
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu collected (1639)
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211276891477: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:25:35 WET [2020/04/03 19:25:35 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #4 is the button
+Seat 1: hellokwanny (16541 in chips) 
+Seat 4: pokeher878787 (12034 in chips) 
+Seat 5: scra88le56 (33381 in chips) 
+Seat 6: 420justblazeit (4378 in chips) 
+Seat 8: winghymliu (31921 in chips) 
+Seat 9: no1beyondfan888 (67929 in chips) 
+scra88le56: posts small blind 50
+420justblazeit: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [8h Qc]
+winghymliu: raises 100 to 200
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: raises 100 to 300
+scra88le56: raises 700 to 1000
+420justblazeit: folds 
+winghymliu: calls 800
+pokeher878787: raises 700 to 1700
+scra88le56: calls 700
+winghymliu: calls 700
+*** FLOP *** [5h 2c Qd]
+scra88le56: checks 
+winghymliu: bets 100
+pokeher878787: raises 2557 to 2657
+scra88le56: folds 
+winghymliu: folds 
+Uncalled bet (2557) returned to pokeher878787
+pokeher878787 collected 5103 from pot
+pokeher878787: doesn't show hand 
+*** SUMMARY ***
+Total pot 5400 | Rake 297 
+Board [5h 2c Qd]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 (button) collected (5103)
+Seat 5: scra88le56 (small blind) folded on the Flop
+Seat 6: 420justblazeit (big blind) folded before Flop
+Seat 8: winghymliu folded on the Flop
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211276964196: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:26:46 WET [2020/04/03 19:26:46 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (16541 in chips) 
+Seat 4: pokeher878787 (15337 in chips) 
+Seat 5: scra88le56 (31681 in chips) 
+Seat 6: 420justblazeit (4278 in chips) 
+Seat 8: winghymliu (30121 in chips) 
+Seat 9: no1beyondfan888 (67929 in chips) 
+420justblazeit: posts small blind 50
+winghymliu: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [7c Td]
+no1beyondfan888: folds 
+hellokwanny: folds 
+pokeher878787: calls 100
+scra88le56: calls 100
+420justblazeit: calls 50
+winghymliu: checks 
+*** FLOP *** [Jh Ad 4s]
+420justblazeit: checks 
+winghymliu: bets 378
+pokeher878787: calls 378
+scra88le56: folds 
+420justblazeit: folds 
+*** TURN *** [Jh Ad 4s] [9c]
+winghymliu: bets 1092
+pokeher878787: folds 
+Uncalled bet (1092) returned to winghymliu
+winghymliu collected 1092 from pot
+winghymliu: doesn't show hand 
+*** SUMMARY ***
+Total pot 1156 | Rake 64 
+Board [Jh Ad 4s 9c]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 folded on the Turn
+Seat 5: scra88le56 (button) folded on the Flop
+Seat 6: 420justblazeit (small blind) folded on the Flop
+Seat 8: winghymliu (big blind) collected (1092)
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211277006613: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:27:28 WET [2020/04/03 19:27:28 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (16541 in chips) 
+Seat 4: pokeher878787 (14859 in chips) 
+Seat 5: scra88le56 (31581 in chips) 
+Seat 6: 420justblazeit (4178 in chips) 
+Seat 8: winghymliu (30735 in chips) 
+Seat 9: no1beyondfan888 (67929 in chips) 
+winghymliu: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Qd 3c]
+hellokwanny: folds 
+pokeher878787: raises 200 to 300
+scra88le56: calls 300
+420justblazeit: folds 
+winghymliu: calls 250
+no1beyondfan888: calls 200
+*** FLOP *** [2s Tc As]
+winghymliu: bets 1134
+no1beyondfan888: folds 
+pokeher878787: calls 1134
+scra88le56: calls 1134
+*** TURN *** [2s Tc As] [7s]
+winghymliu: bets 100
+pokeher878787: raises 4549 to 4649
+scra88le56: raises 4549 to 9198
+winghymliu: folds 
+pokeher878787: raises 4227 to 13425 and is all-in
+scra88le56: calls 4227
+*** RIVER *** [2s Tc As 7s] [Qh]
+*** SHOW DOWN ***
+pokeher878787: shows [Jh Jc] (a pair of Jacks)
+scra88le56: shows [8s Js] (a flush, Ace high)
+scra88le56 collected 29817 from pot
+*** SUMMARY ***
+Total pot 31552 | Rake 1735 
+Board [2s Tc As 7s Qh]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 4: pokeher878787 showed [Jh Jc] and lost with a pair of Jacks
+Seat 5: scra88le56 showed [8s Js] and won (29817) with a flush, Ace high
+Seat 6: 420justblazeit (button) folded before Flop (didn't bet)
+Seat 8: winghymliu (small blind) folded on the Turn
+Seat 9: no1beyondfan888 (big blind) folded on the Flop
+
+
+
+PokerStars Home Game Hand #211277084489: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:28:41 WET [2020/04/03 19:28:41 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #8 is the button
+Seat 1: hellokwanny (16541 in chips) 
+Seat 5: scra88le56 (46539 in chips) 
+Seat 6: 420justblazeit (4178 in chips) 
+Seat 8: winghymliu (29201 in chips) 
+Seat 9: no1beyondfan888 (67629 in chips) 
+no1beyondfan888: posts small blind 50
+hellokwanny: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Ah 5s]
+scra88le56: calls 100
+420justblazeit: raises 200 to 300
+winghymliu: calls 300
+no1beyondfan888: calls 250
+hellokwanny: folds 
+scra88le56: calls 200
+*** FLOP *** [3d Ac Kc]
+no1beyondfan888: checks 
+scra88le56: checks 
+420justblazeit: bets 3878 and is all-in
+winghymliu: folds 
+no1beyondfan888: folds 
+scra88le56: folds 
+Uncalled bet (3878) returned to 420justblazeit
+420justblazeit collected 1228 from pot
+420justblazeit: doesn't show hand 
+*** SUMMARY ***
+Total pot 1300 | Rake 72 
+Board [3d Ac Kc]
+Seat 1: hellokwanny (big blind) folded before Flop
+Seat 5: scra88le56 folded on the Flop
+Seat 6: 420justblazeit collected (1228)
+Seat 8: winghymliu (button) folded on the Flop
+Seat 9: no1beyondfan888 (small blind) folded on the Flop
+
+
+
+PokerStars Home Game Hand #211277136515: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:29:33 WET [2020/04/03 19:29:33 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #9 is the button
+Seat 1: hellokwanny (16441 in chips) 
+Seat 5: scra88le56 (46239 in chips) 
+Seat 6: 420justblazeit (5106 in chips) 
+Seat 8: winghymliu (28901 in chips) 
+Seat 9: no1beyondfan888 (67329 in chips) 
+hellokwanny: posts small blind 50
+scra88le56: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [4d 3d]
+420justblazeit: folds 
+winghymliu: folds 
+no1beyondfan888: folds 
+hellokwanny: raises 100 to 200
+scra88le56: calls 100
+*** FLOP *** [Ks As Ac]
+hellokwanny: bets 200
+scra88le56: folds 
+Uncalled bet (200) returned to hellokwanny
+hellokwanny collected 378 from pot
+hellokwanny: doesn't show hand 
+*** SUMMARY ***
+Total pot 400 | Rake 22 
+Board [Ks As Ac]
+Seat 1: hellokwanny (small blind) collected (378)
+Seat 5: scra88le56 (big blind) folded on the Flop
+Seat 6: 420justblazeit folded before Flop (didn't bet)
+Seat 8: winghymliu folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 (button) folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211277162702: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:29:59 WET [2020/04/03 19:29:59 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #1 is the button
+Seat 1: hellokwanny (16619 in chips) 
+Seat 5: scra88le56 (46039 in chips) 
+Seat 6: 420justblazeit (5106 in chips) 
+Seat 8: winghymliu (28901 in chips) 
+Seat 9: no1beyondfan888 (67329 in chips) 
+scra88le56: posts small blind 50
+420justblazeit: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [Ts 2c]
+winghymliu: folds 
+no1beyondfan888: folds 
+hellokwanny: folds 
+scra88le56: raises 100 to 200
+420justblazeit: calls 100
+*** FLOP *** [5d 4h 7d]
+scra88le56: bets 189
+420justblazeit: calls 189
+*** TURN *** [5d 4h 7d] [6h]
+scra88le56: checks 
+420justblazeit: bets 4717 and is all-in
+scra88le56: folds 
+Uncalled bet (4717) returned to 420justblazeit
+420justblazeit collected 735 from pot
+420justblazeit: doesn't show hand 
+*** SUMMARY ***
+Total pot 778 | Rake 43 
+Board [5d 4h 7d 6h]
+Seat 1: hellokwanny (button) folded before Flop (didn't bet)
+Seat 5: scra88le56 (small blind) folded on the Turn
+Seat 6: 420justblazeit (big blind) collected (735)
+Seat 8: winghymliu folded before Flop (didn't bet)
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211277210208: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:30:46 WET [2020/04/03 19:30:46 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #5 is the button
+Seat 1: hellokwanny (16619 in chips) 
+Seat 5: scra88le56 (45650 in chips) 
+Seat 6: 420justblazeit (5452 in chips) 
+Seat 8: winghymliu (28901 in chips) 
+Seat 9: no1beyondfan888 (67329 in chips) 
+420justblazeit: posts small blind 50
+winghymliu: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [9d 7s]
+no1beyondfan888: folds 
+hellokwanny: folds 
+scra88le56: folds 
+420justblazeit: calls 50
+winghymliu: raises 200 to 300
+420justblazeit: calls 200
+*** FLOP *** [Ac Qd Ad]
+420justblazeit: bets 567
+winghymliu: folds 
+Uncalled bet (567) returned to 420justblazeit
+420justblazeit collected 567 from pot
+420justblazeit: doesn't show hand 
+*** SUMMARY ***
+Total pot 600 | Rake 33 
+Board [Ac Qd Ad]
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 5: scra88le56 (button) folded before Flop (didn't bet)
+Seat 6: 420justblazeit (small blind) collected (567)
+Seat 8: winghymliu (big blind) folded on the Flop
+Seat 9: no1beyondfan888 folded before Flop (didn't bet)
+
+
+
+PokerStars Home Game Hand #211277250097: {Club #3220300}  Hold'em No Limit (50/100) - 2020/04/04 0:31:26 WET [2020/04/03 19:31:26 ET]
+Table '3 April 10p BB' 9-max (Play Money) Seat #6 is the button
+Seat 1: hellokwanny (16619 in chips) 
+Seat 5: scra88le56 (45650 in chips) 
+Seat 6: 420justblazeit (5719 in chips) 
+Seat 8: winghymliu (28601 in chips) 
+Seat 9: no1beyondfan888 (67329 in chips) 
+winghymliu: posts small blind 50
+no1beyondfan888: posts big blind 100
+*** HOLE CARDS ***
+Dealt to hellokwanny [3s 9d]
+hellokwanny: folds 
+scra88le56: raises 600 to 700
+420justblazeit: folds 
+winghymliu: folds 
+no1beyondfan888: folds 
+Uncalled bet (600) returned to scra88le56
+scra88le56 collected 250 from pot
+scra88le56: doesn't show hand 
+*** SUMMARY ***
+Total pot 250 | Rake 0 
+Seat 1: hellokwanny folded before Flop (didn't bet)
+Seat 5: scra88le56 collected (250)
+Seat 6: 420justblazeit (button) folded before Flop (didn't bet)
+Seat 8: winghymliu (small blind) folded before Flop
+Seat 9: no1beyondfan888 (big blind) folded before Flop
+
+
+

--- a/rake_calculator.py
+++ b/rake_calculator.py
@@ -1,4 +1,5 @@
 import sys
+import re
 from collections import defaultdict
 from decimal import Decimal as D
 
@@ -8,14 +9,25 @@ print('Opening file ' + file_name)
 
 winnings = defaultdict(int)
 total_rake = 0
+hands = set()
 
-with open(file_name, 'r') as f:
+with open(file_name, 'r', encoding='utf-8-sig') as f:
 
     current_takers = set()
     current_rake = 0
 
+    in_summary   = True
+    in_hand = True
+
     for line in f:
-        if "collected" in line:
+        if line[0:10] == "PokerStars":
+            in_hand = True
+            in_summary = False
+            hand_number_search = re.search('PokerStars.*(#[0-9]*?):\s.*', line)
+            if hand_number_search:
+                found = hand_number_search.group(1);
+                hands.add(found)
+        elif "collected" in line and in_summary:
             print(line)
             before_collected = line.split(' collected ')[0]
             name = before_collected.split(' ')[-1]
@@ -43,5 +55,6 @@ for name, amount in winnings.items():
     print('Name: ' + name + " Rake winnings: " + str(amount))
 
 print("Total Rake: " + str(total_rake))
+print("Number of hands:" + str(len(hands)))
 print("Finished!")
 

--- a/rake_calculator.py
+++ b/rake_calculator.py
@@ -9,52 +9,68 @@ print('Opening file ' + file_name)
 
 winnings = defaultdict(int)
 total_rake = 0
-hands = set()
+hand_numbers = set()
 
 with open(file_name, 'r', encoding='utf-8-sig') as f:
 
-    current_takers = set()
     current_rake = 0
 
-    in_summary   = True
-    in_hand = True
+    in_summary = False
+    in_hand = False
+
+    hand = defaultdict(int)
 
     for line in f:
         if line[0:10] == "PokerStars":
+            # Reset hand
+            print(line)
+            
             in_hand = True
             in_summary = False
-            hand_number_search = re.search('PokerStars.*(#[0-9]*?):\s.*', line)
-            if hand_number_search:
-                found = hand_number_search.group(1);
-                hands.add(found)
-        elif "collected" in line and in_summary:
-            print(line)
-            before_collected = line.split(' collected ')[0]
-            name = before_collected.split(' ')[-1]
-            current_takers.add(name)
-            print(name)
-        elif "Rake" in line:
-            print(line)
-            current_rake = D(line.split('Rake ')[1])
-            print(current_rake)
-
-            if current_rake and current_takers:
-                split_winnings = current_rake / len(current_takers)
-
-                for taker in current_takers:
-                    winnings[taker] += split_winnings
-
-            # For Audit
-            total_rake += current_rake
-
-            current_takers.clear()
             current_rake = 0
+            hand.clear()
+            
+            hand_number_line = re.search('PokerStars.*(#[0-9]*?):\s.*', line)
+            if hand_number_line:
+                found = hand_number_line.group(1);
+                hand_numbers.add(found)
+        elif line[0:15] == "*** SUMMARY ***":
+            # Start processing SUMMARY
+            print(line)
+            in_hand = False
+            in_summary = True
+        elif in_summary:
+            pot_rake_line = re.search('Total pot.*\| Rake ([0-9]*?)\s', line)
+            seat_line = re.search('Seat [0-9]: (\S*\s).*(won|collected) \(([0-9]*?)\)', line)
+            if seat_line:
+                # Capture player and won/collected amount
+                print(line)
+                player = seat_line.group(1)
+                seat_won_amount = seat_line.group(3)
+                print("Won amount: " + seat_won_amount + " by " + player)
+                hand[player] += int(seat_won_amount)
+            elif pot_rake_line:
+                # Capture rake amount for the hand
+                print(line)
+                pot_rake_amount = pot_rake_line.group(1)
+                print("Rake Amount: " + pot_rake_amount)
+                current_rake = int(pot_rake_amount)
+            elif len(line.strip()) == 0:
+                # End of SUMMARY, now process the rakes for the hand
+                in_summary = False
+                total_won = sum(hand.values())
+                total_rake += current_rake
+                for name, won_amount in hand.items():
+                    print("Rake Amount " + str(current_rake))
+                    attributed_rake = won_amount / total_won * current_rake
+                    print("Attribute rake " + str(attributed_rake) + " to " + name)
+                    winnings[name] += attributed_rake
 
 print("Finished processing, showing rake takers")
 for name, amount in winnings.items():
     print('Name: ' + name + " Rake winnings: " + str(amount))
 
 print("Total Rake: " + str(total_rake))
-print("Number of hands:" + str(len(hands)))
+print("Number of hands:" + str(len(hand_numbers)))
 print("Finished!")
 


### PR DESCRIPTION
Should fully calculate attributed rake value from PokerStars. Can/should be enhanced to add in multiple files, the hand_numbers set can be used to ignore duplicate hand numbers across multiple files